### PR TITLE
On no follows, stream_for_user returns None.  It should return an empty Action queryset instead.

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -21,6 +21,9 @@ class FollowManager(models.Manager):
         qs = (Action.objects.stream_for_actor(follow.actor) for follow in follows)
         if follows.count():
             return reduce(or_, qs).order_by('-timestamp')
+
+        return Action.objects.none()
+
     
 class Follow(models.Model):
     """


### PR DESCRIPTION
Justin,

I use your code quite a bit, but this patch fixes my biggest headache: if the user is following no one, stream_for_user returns None, instead of an empty Action queryset.  The patch is straightforward, and will keep me from having to maintain my own branch.  :-)
