### PR TITLE
Unfollow was not working

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -162,7 +162,7 @@ def follow(user, actor, send_action=True):
     """
     follow,created = Follow.objects.get_or_create(user=user, object_id=actor.pk, 
         content_type=ContentType.objects.get_for_model(actor))
-    if send_action:
+    if send_action and created:
         action.send(user, verb=_('started following'), target=actor)
     return follow
 

--- a/actstream/urls.py
+++ b/actstream/urls.py
@@ -15,7 +15,7 @@ urlpatterns = patterns('actstream.views',
     url(r'^follow/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',
         'follow_unfollow', name='actstream_follow'),
     url(r'^unfollow/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',
-        'follow_unfollow', {'follow':False}, 'actstream_unfollow'),
+        'follow_unfollow', {'do_follow':False}, name='actstream_unfollow'),
     
     # Follower and Actor lists
     url(r'^followers/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',


### PR DESCRIPTION
The unfollow action was not working because the url had follow set to false instead of do_follow. 

Also, if you make a multiple request to follow an actor, the follow activity was posted in the stream everytime. So, I added small fix to only do it when a follow relationship is being created. 

Let me know what you think.
