### PR TITLE
Fixed bug in __unicode__ function of Action class

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -92,7 +92,7 @@ class Action(models.Model):
             else:
                 return u'%s %s %s %s ago' % (self.actor, self.verb, self.target, self.timesince())
         if self.action_object:
-            return u'%s %s %s %s %s ago' % (self.actor, self.verb, self.action_object, self.timesince())
+            return u'%s %s %s %s ago' % (self.actor, self.verb, self.action_object, self.timesince())
         return u'%s %s %s ago' % (self.actor, self.verb, self.timesince())
 
     def actor_url(self):

--- a/actstream/templates/activity/action.html
+++ b/actstream/templates/activity/action.html
@@ -2,7 +2,7 @@
 {% else %}<a href="{{ action.actor_url }}">{{ action.actor }}</a>{% endif %}
 {{ action.verb }}
 {% if action.target %}
-    {% if action.action_object.get_absolute_url %}<a href="{{ action.target.get_absolute_url }}">{{ action.action_object }}</a>
-    {% else %}<a href="{{ action.action_object.target_url }}">{{ action.action_object }}</a>{% endif %}
+    {% if action.target.get_absolute_url %}<a href="{{ action.target.get_absolute_url }}">{{ action.target }}</a>
+    {% else %}<a href="{{ action.target_url }}">{{ action.target }}</a>{% endif %}
 {% endif %}
 {{ action.timestamp|timesince }} {% trans "ago" %}


### PR DESCRIPTION
In the case where the Action object has no target, the **unicode** method returns '%s %s %s %s %s ago' (5 string parameters), but only takes 4 string parameters. This update fixes that bug, which currently causes the Django Admin to throw a TemplateSyntaxError when such an entry without a target exists.
