### PR TITLE
fixed test (test_atom)

### DIFF
--- a/actstream/tests.py
+++ b/actstream/tests.py
@@ -93,7 +93,8 @@ class ActivityTestCase(TestCase):
     def test_atom(self):
         atom = self.client.get('/feed/atom/').content
         self.assert_(atom.startswith('<?xml version="1.0" encoding="utf-8"?>\n'
-            '<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-us">'))
+            '<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="%s">' %
+                                     settings.LANGUAGE_CODE))
         self.assert_(atom.find('Activity feed for your followed actors') > -1)
 
     def test_action_object(self):


### PR DESCRIPTION
I'm working on a project which have a different language than english.
In `ActivityTestCase.test_atom` the laguage code `en-us` is hard-coded in the xml string during assertation, so this test always fails for me.

I changed it, to use the `LANGUAGE_CODE` from `django.conf.settings`.

By the way, nice work guys, keep going!
