### PR TITLE
Allow field lookups to be passed as keyword arguments to model_stream and user_stream functions

### DIFF
--- a/actstream/managers.py
+++ b/actstream/managers.py
@@ -51,9 +51,10 @@ class ActionManager(GFKManager):
         """
         ctype = ContentType.objects.get_for_model(model)
         return self.public(
-            Q(target_content_type=ctype) |
+            (Q(target_content_type=ctype) |
             Q(action_object_content_type=ctype) |
-            Q(actor_content_type=ctype)
+            Q(actor_content_type=ctype)),
+            **kwargs
         )
 
     @stream
@@ -81,7 +82,7 @@ class ActionManager(GFKManager):
                 actor_content_type=content_type_id,
                 actor_object_id__in=object_ids,
             )
-        qs = qs.filter(q)
+        qs = qs.filter(q, **kwargs)
         return qs
 
 

--- a/actstream/tests.py
+++ b/actstream/tests.py
@@ -197,6 +197,24 @@ class ActivityTestCase(TestCase):
     def test_after_slice(self):
         return 10,  10
 
+    def test_model_actions_with_kwargs(self):
+        """
+        Testing the model_actions method of the ActionManager
+        by passing kwargs
+        """
+        self.assertEqual(map(unicode, model_stream(self.user1, verb='commented on')), [
+                u'admin commented on CoolGroup 0 minutes ago',
+                ])
+
+    def test_user_stream_with_kwargs(self):
+        """
+        Testing the user method of the ActionManager by passing additional
+        filters in kwargs
+        """
+        self.assertEqual(map(unicode, Action.objects.user(self.user1, verb='joined')), [
+                u'Two joined CoolGroup 0 minutes ago',
+                ])
+
     def tearDown(self):
         Action.objects.all().delete()
         User.objects.all().delete()


### PR DESCRIPTION
I have made some minor modifications to the `user` and `model_actions` methods of the ActionManager so that any field lookup arguments can be directly passed to them as keyword args, so there is no need of calling filter again on the returned query set. 

Thanks for this useful application. I learnt a lot from your code :) 
