### PR TITLE
Enable doing actions in the example project

### DIFF
--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -116,7 +116,7 @@ ABSOLUTE_URL_OVERRIDES = {
 
 ACCOUNT_ACTIVATION_DAYS = 7
 
-ACTSTREAM_ACTION_MODELS = ('auth.user', 'auth.group', 'sites.site')
+ACTSTREAM_ACTION_MODELS = ('auth.user', 'auth.group', 'sites.site', 'comments.comment')
 
 ACTSTREAM_MANAGER = 'testapp.streams.MyActionManager'
 

--- a/example_project/templates/base.html
+++ b/example_project/templates/base.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 
@@ -30,6 +32,11 @@
 			<ul id="navlist">
 				<li><b><a href="/">HOME</a></b></li>
 				{% block navlinks %}{% endblock %}
+				{% if request.user.is_authenticated %}
+				<li>
+					<a href="{% url 'django.contrib.auth.views.logout' %}">{% trans 'LOGOUT' %}</a>
+				</li>
+				{% endif %}
 			</ul>
 		</div>
 	</div>
@@ -37,6 +44,14 @@
 
 <div id="content">
 	<p><b>Active users</b>{% for user in users %} | <a href="{{ user.get_absolute_url }}">{{ user }}</a>{% endfor %}</p>
+
+	{% if request.user.is_authenticated %}
+		{% load comments %}
+		{% render_comment_form for request.user %}
+	{% else %}
+		<p>{% trans "Please login before you can start doing action" %}</p>
+	{% endif %}
+
 	<h2>{% block content_title %}{% endblock %}</h2>
 	{% block content %}{% endblock %}
 </div>

--- a/example_project/templates/comments/base.html
+++ b/example_project/templates/comments/base.html
@@ -1,0 +1,1 @@
+{% extends 'base.html' %}

--- a/example_project/templates/comments/form.html
+++ b/example_project/templates/comments/form.html
@@ -1,0 +1,40 @@
+{% load comments i18n %}
+<div class="comment_form_container">
+    <form action="{% comment_form_target %}" method="post">{% csrf_token %}
+      {% if next %}<input type="hidden" name="next" value="{{ next }}" />{% endif %}
+
+      {% if request.user.is_authenticated %}
+        <input type="hidden" name="name" value="{{ request.user }}" />
+      {% else %}
+        {% if form.name.errors %}{{ form.name.errors }}{% endif %}
+        {% trans 'your name' %}: {{ form.name }}
+      {% endif %}
+
+      {% if request.user.is_authenticated %}
+        <input type="hidden" email="email" value="{{ request.user }}" />
+      {% else %}
+        {% if form.email.errors %}{{ form.email.errors }}{% endif %}
+        {% trans 'your email' %}: {{ form.email }}
+      {% endif %}
+      
+      {% if form.comment.errors %}{{ form.comment.errors }}{% endif %}
+
+      {{ form.comment }}
+
+      {% if not request.user.is_authenticated %}
+      <br />
+      {{ form.honeypot.label_tag }}: {{ form.honeypot }}
+      {% endif %}
+
+      {% for field in form %}
+        {% if field.is_hidden %}
+          {{ field }}
+        {% endif %}
+      {% endfor %}
+      <p class="submit">
+        <input type="submit" name="post" class="submit-post" value="{% trans "Post" %}" />
+        <!--<input type="submit" name="preview" class="submit-preview" value="{% trans "Preview" %}" />-->
+      </p>
+    </form>
+</div>
+

--- a/example_project/testapp/models.py
+++ b/example_project/testapp/models.py
@@ -1,5 +1,13 @@
 from django.db import models
+from django.contrib.comments.signals import comment_was_posted
 
+from actstream import action
+
+def comment_action(sender, comment=None, target=None, **kwargs):
+    if comment.user:
+        action.send(comment.user, verb=u'commented', action_object=comment, 
+            target=comment.content_object)
+comment_was_posted.connect(comment_action)
 
 class Player(models.Model):
     state = models.IntegerField(default=0)

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -11,6 +11,7 @@ urlpatterns = patterns('',
     (r'^accounts/', include('registration.backends.default.urls')),
     (r'^media/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': os.path.join(os.path.dirname(__file__), 'media')}),
+    (r'auth/', include('django.contrib.auth.urls')),
     (r'', include('actstream.urls')),
 )
 


### PR DESCRIPTION
Currently, the example project does not provide a way to generate actions.

The purpose of this patch is to enable action generation in the example project in the simplest way possible, using what's installed - not adding new models etc ...

This patch adds a comment form for request.user in base.html as well as a receiver for comment_was_posted that calls action.send.

It will allow me to demonstrate the patch with better I18N support that i want to make.
