### PR TITLE
Remove follow tag

### DIFF
--- a/actstream/templatetags/activity_tags.py
+++ b/actstream/templatetags/activity_tags.py
@@ -8,23 +8,6 @@ from actstream.models import Follow
 register = Library()
 
 
-def _is_following_helper(context, actor):
-    return Follow.objects.is_following(context.get('user'), actor)
-
-
-class DisplayActivityFollowLabel(Node):
-    def __init__(self, actor, follow, unfollow):
-        self.actor = Variable(actor)
-        self.follow = follow
-        self.unfollow = unfollow
-
-    def render(self, context):
-        actor_instance = self.actor.resolve(context)
-        if _is_following_helper(context, actor_instance):
-            return self.follow
-        return self.unfollow
-
-
 class DisplayActivityFollowUrl(Node):
     def __init__(self, actor):
         self.actor = Variable(actor)
@@ -32,7 +15,7 @@ class DisplayActivityFollowUrl(Node):
     def render(self, context):
         actor_instance = self.actor.resolve(context)
         content_type = ContentType.objects.get_for_model(actor_instance).pk
-        if _is_following_helper(context, actor_instance):
+        if Follow.objects.is_following(context.get('user'), actor_instance):
             return reverse('actstream_unfollow', kwargs={
                 'content_type_id': content_type, 'object_id': actor_instance.pk})
         return reverse('actstream_follow', kwargs={
@@ -118,11 +101,11 @@ def display_action(parser, token):
 
 def is_following(user, actor):
     """
-    Returns true if the given request.user is following the actor
+    Returns true if the given user is following the actor
 
     Example::
 
-        {% if request.user|is_following:another_user %}
+        {% if user|is_following:another_user %}
             You are already following {{ another_user }}
         {% endif %}
     """
@@ -135,7 +118,13 @@ def follow_url(parser, token):
 
     Example::
 
-        <a href="{% follow_url request.user %}">{% follow_label request.user 'stop following' 'follow' %}</a>
+        <a href="{% follow_url other_user %}">
+            {% if user|is_following:other_user %}
+                stop following
+            {% else %}
+                follow
+            {% endif %}
+        </a>
 
     """
     bits = token.split_contents()
@@ -145,29 +134,13 @@ def follow_url(parser, token):
     return DisplayActivityFollowUrl(bits[1])
 
 
-def follow_label(parser, token):
-    """
-    Renders the label for following/unfollowing for a particular actor instance
-
-    Example::
-
-        <a href="{% follow_url request.user %}">{% follow_label request.user 'stop following' 'follow' %}</a>
-
-    """
-    bits = token.split_contents()
-    if len(bits) != 4:
-        raise TemplateSyntaxError("Accepted format "
-            "{% follow_label [instance] [follow_string] [unfollow_string] %}")
-    return DisplayActivityFollowLabel(*bits[1:])
-
-
 def actor_url(parser, token):
     """
     Renders the URL for a particular actor instance
 
     Example::
 
-        <a href="{% actor_url request.user %}">View your actions</a>
+        <a href="{% actor_url user %}">View your actions</a>
         <a href="{% actor_url another_user %}">{{ another_user }}'s actions</a>
 
     """
@@ -181,5 +154,4 @@ def actor_url(parser, token):
 register.filter(is_following)
 register.tag(display_action)
 register.tag(follow_url)
-register.tag(follow_label)
 register.tag(actor_url)

--- a/actstream/tests.py
+++ b/actstream/tests.py
@@ -189,28 +189,6 @@ class ActivityTestCase(ActivityBaseTestCase):
         ct = ContentType.objects.get_for_model(User)
         self.assertEqual(output, '/follow/%s/%s/' % (ct.pk, self.user1.pk))
 
-    def test_tag_follow_label(self):
-        src = '{% load activity_tags %}'\
-            '{% follow_label other_user yup nope %}'
-
-        # Anonymous.
-        output = Template(src).render(Context({'other_user': self.user1}))
-        self.assertEqual(output, 'nope')
-
-        output = Template(src).render(Context({'user': AnonymousUser(),
-            'other_user': self.user1}))
-        self.assertEqual(output, 'nope')
-
-        # Non follower (user2 does not follow user1).
-        output = Template(src).render(Context({'user': self.user2,
-            'other_user': self.user1}))
-        self.assertEqual(output, 'nope')
-
-        # Follower (user1 follows user2).
-        output = Template(src).render(Context({'user': self.user1,
-            'other_user': self.user2}))
-        self.assertEqual(output, 'yup')
-
     def test_model_actions_with_kwargs(self):
         """
         Testing the model_actions method of the ActionManager

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -35,4 +35,4 @@ Templatetags
 -------------
 
 .. automodule:: actstream.templatetags.activity_tags
-    :members: is_following,display_action,follow_url,follow_label,actor_url
+    :members: is_following,display_action,follow_url,actor_url


### PR DESCRIPTION
While you're cleaning up tags, you may as well remove this one. It's redundant (and the recently changed docstring usage was actually incorrect)
