### PR TITLE
Fix the way follow_label handles quotes

### DIFF
--- a/actstream/templatetags/activity_tags.py
+++ b/actstream/templatetags/activity_tags.py
@@ -18,7 +18,7 @@ def _remove_quotes(parameter):
         return parameter[1:-1]
     else:
         return parameter
-    
+
 class DisplayActivityFollowLabel(Node):
     def __init__(self, actor, follow, unfollow):
         self.actor = Variable(actor)
@@ -32,8 +32,9 @@ class DisplayActivityFollowLabel(Node):
         return _remove_quotes(self.unfollow)
 
 class DisplayActivityFollowUrl(Node):
-    def __init__(self, actor):
+    def __init__(self, actor, actor_only=True):
         self.actor = Variable(actor)
+        self.actor_only = actor_only
 
     def render(self, context):
         actor_instance = self.actor.resolve(context)
@@ -41,7 +42,10 @@ class DisplayActivityFollowUrl(Node):
         if _is_following_helper(context, actor_instance):
             return reverse('actstream_unfollow', kwargs={
                 'content_type_id': content_type, 'object_id': actor_instance.pk})
-        return reverse('actstream_follow', kwargs={
+        if self.actor_only:
+            return reverse('actstream_follow', kwargs={
+                'content_type_id': content_type, 'object_id': actor_instance.pk})
+        return reverse('actstream_follow_all', kwargs={
             'content_type_id': content_type, 'object_id': actor_instance.pk})
 
 class DisplayActivityActorUrl(Node):
@@ -145,6 +149,20 @@ def follow_url(parser, token):
     else:
         return DisplayActivityFollowUrl(bits[1])
 
+def follow_all_url(parser, token):
+    """
+    Renders the URL to follow an object as both actor and target
+
+    Example::
+
+        <a href="{% follow_all_url request.user %}">{% follow_label request.user 'stop following' 'follow' %}</a>
+
+    """
+    bits = token.split_contents()
+    if len(bits) != 2:
+        raise TemplateSyntaxError, "Accepted format {% follow_all_url [instance] %}"
+    else:
+        return DisplayActivityFollowUrl(bits[1], actor_only=False)
 
 def follow_label(parser, token):
     """
@@ -180,5 +198,6 @@ def actor_url(parser, token):
 register.filter(is_following)
 register.tag(display_action)
 register.tag(follow_url)
+register.tag(follow_all_url)
 register.tag(follow_label)
 register.tag(actor_url)

--- a/actstream/urls.py
+++ b/actstream/urls.py
@@ -21,6 +21,8 @@ urlpatterns = patterns('actstream.views',
     # Follow/Unfollow API
     url(r'^follow/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',
         'follow_unfollow', name='actstream_follow'),
+    url(r'^follow_all/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',
+        'follow_unfollow', {'actor_only': False}, name='actstream_follow_all'),
     url(r'^unfollow/(?P<content_type_id>\d+)/(?P<object_id>\d+)/$',
         'follow_unfollow', {'do_follow': False}, name='actstream_unfollow'),
 

--- a/actstream/views.py
+++ b/actstream/views.py
@@ -22,7 +22,7 @@ def respond(request, code):
 
 @login_required
 @csrf_exempt
-def follow_unfollow(request, content_type_id, object_id, do_follow=True):
+def follow_unfollow(request, content_type_id, object_id, do_follow=True, actor_only=True):
     """
     Creates or deletes the follow relationship between ``request.user`` and the
     actor defined by ``content_type_id``, ``object_id``.
@@ -31,7 +31,7 @@ def follow_unfollow(request, content_type_id, object_id, do_follow=True):
     actor = get_object_or_404(ctype.model_class(), pk=object_id)
 
     if do_follow:
-        actions.follow(request.user, actor)
+        actions.follow(request.user, actor, actor_only=actor_only)
         return respond(request, 201)   # CREATED
     actions.unfollow(request.user, actor)
     return respond(request, 204)   # NO CONTENT

--- a/example_project/templates/base.html
+++ b/example_project/templates/base.html
@@ -45,7 +45,7 @@
 
 <div id="content">
 	<p><b>Active users</b>{% for user in users %} | <a href="{{ user.get_absolute_url }}">{{ user }}</a>{% endfor %}</p>
-	<a href="{% follow_url request.user %}">{% follow_label user 'stop following' 'follow' %}</a>
+	<a href="{% follow_all_url request.user %}">{% follow_label user 'stop following' 'follow' %}</a>
 	{% if request.user.is_authenticated %}
 		{% load comments %}
 		{% render_comment_form for request.user %}


### PR DESCRIPTION
For example:
    {% follow_label 'stop following' 'follow' %}
Should output the word 'follow' without quotes around it
