### PR TITLE
Making the output of a Model custom flexible

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -100,12 +100,13 @@ class Action(models.Model):
 
     def __unicode__(self):
         ctx = {
-            'actor': self.actor,
-            'verb': self.verb,
-            'action_object': self.action_object,
-            'target': self.target,
-            'timesince': self.timesince()
+            'actor': self.actor.__stream__() if hasattr(self.actor, '__stream__') else self.actor,
+            'verb': self.verb.__stream__() if hasattr(self.verb, '__stream__') else self.verb,
+            'action_object': self.action_object.__stream__() if hasattr(self.action_object, '__stream__') else self.action_object,
+            'target': self.target.__stream__() if hasattr(self.target, '__stream__') else self.target,
+            'timesince': self.timesince(),
         }
+
         if self.target:
             if self.action_object:
                 return _('%(actor)s %(verb)s %(action_object)s on %(target)s %(timesince)s ago') % ctx


### PR DESCRIPTION
It would be nice that the models had a special method, that if defined was called for the string representation. This gives a nice extra abstraction layer if needed.

Usually `__unicode__` is defined in a verbose way for debugging purposes. Other times you may point to a model that has many fields represented in this method, but for the user you just want to show one in a different way. Somehow I find there is an impedance between `__unicode__` and the outer world.

I've named the method `__stream__` so that it looks like `__unicode__`, but feel free to rename it if you don't like it.

Cheers,
Miguel
