### PR TITLE
Added missing MODEL field to ACTSTREAM_SETTING in example project

### DIFF
--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -94,7 +94,10 @@ INSTALLED_APPS = (
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
+    # for django 1.2 or 1.3
     'django.core.context_processors.auth',
+    # for django 1.4 comment above line and uncomment below
+    #'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.i18n',
     'django.core.context_processors.media',


### PR DESCRIPTION
Hey,

The example project does not work without adding this line, I figured it out pretty quick but a beginner might not. I also added the line required to make the project work on 1.4 but commented out. This is due to moving the auth context processor in 1.4 onwards.

Great work on the application, I hope this is useful.

Cheers,

Chris
