### PR TITLE
Avoid deprecation warning (django 1.5)

### DIFF
--- a/actstream/urls.py
+++ b/actstream/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from actstream import feeds
 
 urlpatterns = patterns('actstream.views',


### PR DESCRIPTION
django.conf.urls.defaults is deprecated; use django.conf.urls instead
