### PR TITLE
fix south migration warnings

### DIFF
--- a/actstream/migrations/0007_auto__add_field_follow_started.py
+++ b/actstream/migrations/0007_auto__add_field_follow_started.py
@@ -4,11 +4,18 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+try:
+    # timezone support for django > 1.4
+    from django.utils import timezone
+    tz = timezone                                                                
+except ImportError:
+    tz = datetime.datetime  
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Adding field 'Follow.started'
-        db.add_column('actstream_follow', 'started', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now), keep_default=False)
+        db.add_column('actstream_follow', 'started', self.gf('django.db.models.fields.DateTimeField')(default=tz.now), keep_default=False)
 
     def backwards(self, orm):
         # Deleting field 'Follow.started'


### PR DESCRIPTION
When running unit tests against my django apps, I am tired of seeing the warning from actstream's internal migrations that say: `DateTimeField received a naive datetime (2013-05-06 18:08:44.244158) while time zone support is active.`. This change removes the warning by using a workaround needed for South v0.7.6.
