### PR TITLE
Stop bad data from breaking activity stream

### DIFF
--- a/actstream/gfk.py
+++ b/actstream/gfk.py
@@ -74,14 +74,17 @@ class GFKQuerySet(QuerySet):
 
         for item in qs:
             for gfk in gfk_fields:
-                if getattr(item, gfk.fk_field) != None:
-                    ct_id_field = self.model._meta.get_field(gfk.ct_field)\
-                        .column
-                    setattr(item, gfk.name,
-                        data_map[(
-                            getattr(item, ct_id_field),
-                            smart_unicode(getattr(item, gfk.fk_field))
-                        )])
+                try:
+                    if getattr(item, gfk.fk_field) is not None:
+                        ct_id_field = self.model._meta.get_field(gfk.ct_field)\
+                            .column
+                        setattr(item, gfk.name,
+                            data_map[(
+                                getattr(item, ct_id_field),
+                                smart_unicode(getattr(item, gfk.fk_field))
+                            )])
+                except KeyError:
+                    continue
 
         return qs
 


### PR DESCRIPTION
Not much of a patch, but I've recently inherited a project that uses this. The project has some invalid data or keys that refer to deleted items living in actstream_action and this was causing template tags to blow up. This pull request simply ignores any KeyErrors and returns the rest of the stream.
