### PR TITLE
Fixes for migrations to work with Django 1.5 

### DIFF
--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0002_auto__chg_field_action_timestamp.py
+++ b/actstream/migrations/0002_auto__chg_field_action_timestamp.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0003_text_field_ids.py
+++ b/actstream/migrations/0003_text_field_ids.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0004_char_field_ids.py
+++ b/actstream/migrations/0004_char_field_ids.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0005_auto__add_field_follow_actor_only.py
+++ b/actstream/migrations/0005_auto__add_field_follow_actor_only.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0006_auto__add_field_action_data.py
+++ b/actstream/migrations/0006_auto__add_field_action_data.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0007_auto__add_field_follow_started.py
+++ b/actstream/migrations/0007_auto__add_field_follow_started.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     tz = datetime.datetime
 
-from actstream.migrations.compat import User, USER_ORM
+from actstream.migrations import User, USER_ORM
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/__init__.py
+++ b/actstream/migrations/__init__.py
@@ -1,0 +1,4 @@
+from actstream.compat import get_user_model
+
+User = get_user_model()
+USER_ORM = "%s.%s" % (User._meta.app_label, User._meta.module_name)

--- a/actstream/migrations/compat.py
+++ b/actstream/migrations/compat.py
@@ -1,5 +1,0 @@
-from actstream.compat import get_user_model
-
-
-User = get_user_model()
-USER_ORM = "%s.%s" % (User._meta.app_label, User._meta.module_name)


### PR DESCRIPTION
This is related to justquick/django-activity-stream/pull/144 . 

The current batch of migrations will not work because they are referecing another project and module that is not part of `django-activity-stream`.
