### PR TITLE
import the compat module from actstream, not from djangoratings

### DIFF
--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -4,13 +4,13 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Adding model 'Follow'
         db.create_table('actstream_follow', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
@@ -41,7 +41,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Removing unique constraint on 'Follow', fields ['user', 'content_type', 'object_id']
         db.delete_unique('actstream_follow', ['user_id', 'content_type_id', 'object_id'])
 

--- a/actstream/migrations/0002_auto__chg_field_action_timestamp.py
+++ b/actstream/migrations/0002_auto__chg_field_action_timestamp.py
@@ -4,19 +4,19 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Changing field 'Action.timestamp'
         db.alter_column('actstream_action', 'timestamp', self.gf('django.db.models.fields.DateTimeField')())
 
 
     def backwards(self, orm):
-        
+
         # Changing field 'Action.timestamp'
         db.alter_column('actstream_action', 'timestamp', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True))
 

--- a/actstream/migrations/0003_text_field_ids.py
+++ b/actstream/migrations/0003_text_field_ids.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 class Migration(SchemaMigration):
 

--- a/actstream/migrations/0004_char_field_ids.py
+++ b/actstream/migrations/0004_char_field_ids.py
@@ -4,12 +4,12 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Changing field 'Follow.object_id'
         db.alter_column('actstream_follow', 'object_id', self.gf('django.db.models.fields.CharField')(max_length=255))
 
@@ -24,7 +24,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
- 
+
         # Changing field 'Follow.object_id'
         db.alter_column('actstream_follow', 'object_id', self.gf('django.db.models.fields.PositiveIntegerField')())
 
@@ -37,7 +37,7 @@ class Migration(SchemaMigration):
         # Changing field 'Action.target_object_id'
         db.alter_column('actstream_action', 'target_object_id', self.gf('django.db.models.fields.PositiveIntegerField')(null=True))
 
-       
+
     models = {
         'actstream.action': {
             'Meta': {'ordering': "('-timestamp',)", 'object_name': 'Action'},

--- a/actstream/migrations/0005_auto__add_field_follow_actor_only.py
+++ b/actstream/migrations/0005_auto__add_field_follow_actor_only.py
@@ -4,18 +4,18 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Adding field 'Follow.actor_only'
         db.add_column('actstream_follow', 'actor_only', self.gf('django.db.models.fields.BooleanField')(default=True), keep_default=False)
 
 
     def backwards(self, orm):
-        
+
         # Deleting field 'Follow.actor_only'
         db.delete_column('actstream_follow', 'actor_only')
 

--- a/actstream/migrations/0006_auto__add_field_action_data.py
+++ b/actstream/migrations/0006_auto__add_field_action_data.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 
 class Migration(SchemaMigration):

--- a/actstream/migrations/0007_auto__add_field_follow_started.py
+++ b/actstream/migrations/0007_auto__add_field_follow_started.py
@@ -4,14 +4,14 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from djangoratings.compat import user_model_label
+from actstream.compat import user_model_label
 
 try:
     # timezone support for django > 1.4
     from django.utils import timezone
-    tz = timezone                                                                
+    tz = timezone
 except ImportError:
-    tz = datetime.datetime  
+    tz = datetime.datetime
 
 class Migration(SchemaMigration):
 


### PR DESCRIPTION
This replaces the PR from justquick/django-activity-stream/pull/145
I did not see this commit previously: 82536b1140e0c918d994808e2e93ad70832e0810

This will fix the migrations so they work with django 1.4, and django 1.5 with a custom user model. 
