### PR TITLE
Verbs must be stored as unstranslated strings

### DIFF
--- a/actstream/actions.py
+++ b/actstream/actions.py
@@ -90,6 +90,12 @@ def action_handler(verb, **kwargs):
     kwargs.pop('signal', None)
     actor = kwargs.pop('sender')
     check_actionable_model(actor)
+
+    # We must store the unstranslated string
+    # If verb is an ugettext_lazyed string, fetch the original string
+    if hasattr(verb, '_proxy____args'):
+        verb = verb._proxy____args[0]
+
     newaction = Action(
         actor_content_type=ContentType.objects.get_for_model(actor),
         actor_object_id=actor.pk,

--- a/actstream/tests.py
+++ b/actstream/tests.py
@@ -8,6 +8,8 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.template.loader import Template, Context
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import activate, get_language
 
 from actstream.models import Action, Follow, model_stream, user_stream,\
     setup_generic_relations, following, followers
@@ -228,6 +230,18 @@ class ActivityTestCase(ActivityBaseTestCase):
         self.assertEqual(Template(src).render(Context({
             'user': self.user1, 'group': self.group
         })), u'')
+
+    def test_store_untranslated_string(self):
+        lang = get_language()
+        activate("fr")
+        verb = _(u'English')
+
+        assert unicode(verb) == u"Anglais"
+        action.send(self.user1, verb=verb, action_object=self.comment,
+                    target=self.group)
+        self.assertTrue(Action.objects.filter(verb=u'English'))
+        # restore language
+        activate(lang)
 
 
 class ZombieTest(ActivityBaseTestCase):


### PR DESCRIPTION
When actions are generated in a multi language site, the verbs are stored in the language of the user that generated the request. This is a problem because it's imposible to translate.

This pull request stores the original string when using ugettext_lazy.
