### PR TITLE
Fix use of get_user_model()

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -17,9 +17,9 @@ from actstream import settings as actstream_settings
 from actstream.signals import action
 from actstream.actions import action_handler
 from actstream.managers import FollowManager
-from actstream.compat import get_user_model
+from actstream.compat import user_model_label
 
-User = get_user_model()
+User = user_model_label
 
 
 class Follow(models.Model):


### PR DESCRIPTION
Using `get_user_model()` in a `models` init is very dangerous. Because it can try to import your `User` model before it is in the AppCache. This suddenly broke my project. Replaced `user` with the model label, which always works and prevents circular dependency failures.
