### PR TITLE
Fix filters for `following` for multiple models

### DIFF
--- a/actstream/managers.py
+++ b/actstream/managers.py
@@ -168,7 +168,9 @@ class FollowManager(GFKManager):
         Eg following(user, User) will only return users following the given user
         """
         qs = self.filter(user=user)
+        ctype_filters = Q()
         for model in models:
             check(model)
-            qs = qs.filter(content_type=ContentType.objects.get_for_model(model))
+            ctype_filters |= Q(content_type=ContentType.objects.get_for_model(model))
+        qs = qs.filter(ctype_filters)
         return [follow.follow_object for follow in qs.fetch_generic_relations('follow_object')]


### PR DESCRIPTION
If you pass a list of restricted models to `following` it should apply the `OR` operation to filters for the `content_type` field to retrieve all objects. 
Otherwise it returns an empty list.

Might be slow for a very long of models, at which point you should probably use `content_type__app_label` and `content_type__model` filters.
