### PR TITLE
ADD base.html inside templates/actstream/

### DIFF
--- a/actstream/templates/actstream/actor.html
+++ b/actstream/templates/actstream/actor.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'actstream/base.html' %}
 {% load url from future %}
 {% load activity_tags i18n %}
 {% block extra_head %}

--- a/actstream/templates/actstream/base.html
+++ b/actstream/templates/actstream/base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}


### PR DESCRIPTION
This changes allows to override actstream/base.html template if existing base.html template does not have `content` block.
