### PR TITLE
Allow delayed registration with 'app.Model' strings

### DIFF
--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -5,6 +5,7 @@ from actstream import settings
 from actstream.signals import action
 from actstream.actions import action_handler
 from actstream.compat import AppConfig
+from actstream.registry import registry
 
 try:
     from django.db.backends.mysql.base import DatabaseOperations
@@ -23,8 +24,10 @@ class ActstreamConfig(AppConfig):
     name = 'actstream'
 
     def ready(self):
+
         action.connect(action_handler, dispatch_uid='actstream.models')
-        action_class = self.get_model('action')
+
+        registry.ready()
 
         if settings.USE_JSONFIELD:
             try:
@@ -32,6 +35,9 @@ class ActstreamConfig(AppConfig):
             except ImportError:
                 raise ImproperlyConfigured('You must have django-jsonfield installed '
                                            'if you wish to use a JSONField on your actions')
+
+            action_class = self.get_model('action')
+
             JSONField(blank=True, null=True).contribute_to_class(action_class, 'data')
 
         if DatabaseOperations:

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -12,11 +12,20 @@ from django.utils.six import string_types
 from actstream.compat import generic
 
 
+class RegistrationError(Exception):
+    pass
+
+
 def setup_generic_relations(model_class):
     """
     Set up GenericRelations for actionable models.
     """
     Action = get_model('actstream', 'action')
+
+    if Action is None:
+        raise RegistrationError('Unable get actstream.Action. Potential circular imports '
+                                'in initialisation. Try moving actstream app to come after the '
+                                'apps which have models to register in the INSTALLED_APPS setting.')
 
     related_attr_name = 'related_name'
     related_attr_value = 'actions_with_%s' % label(model_class)

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -78,11 +78,22 @@ def validate(model_class, exception_class=ImproperlyConfigured):
 
 class ActionableModelRegistry(dict):
 
+    def __init__(self):
+
+        # List to store references like 'myapp.MyModel' to be processed in the 'ready' function
+        self.string_model_references = []
+
     def register(self, *model_classes_or_labels):
+        """If the input is a string reference like 'myapp.MyModel' we store for processing later in
+        the ``ready`` method. Otherwise we assume it is a class it register it now.
+        """
         for class_or_label in model_classes_or_labels:
-            model_class = validate(class_or_label)
-            if model_class not in self:
-                self[model_class] = setup_generic_relations(model_class)
+            if isinstance(class_or_label, basestring):
+                self.string_model_references.append(class_or_label)
+            else:
+                model_class = validate(class_or_label)
+                if model_class not in self:
+                    self[model_class] = setup_generic_relations(model_class)
 
     def unregister(self, *model_classes_or_labels):
         for class_or_label in model_classes_or_labels:
@@ -98,6 +109,17 @@ class ActionableModelRegistry(dict):
             raise ImproperlyConfigured(
                 'The model %s is not registered. Please use actstream.registry '
                 'to register it.' % model_class.__name__)
+
+    def ready(self):
+        """Imports and registers each string model reference and then clears the references list"""
+
+        for entry in self.string_model_references:
+            model_class = get_model(*entry.split('.'))
+            self.register(model_class)
+
+        # Clear the list so we don't risk double registering a model
+        self.string_model_references = []
+
 
 registry = ActionableModelRegistry()
 register = registry.register


### PR DESCRIPTION
Hi,

These patches introduce support for delayed model registration to avoid issues with cross imports during django's model set up. The issue is that in django 1.6 the `registry.register` method is generally called directly from the users' `models.py` files during import but that method goes off and calls `get_model` which triggers another round of `model` imports which can then get tied up in knots.

The patch allows for delayed model registration using a `'myapp.MyModel'` strings which are processed from the `ActstreamConfig.ready` method which is generally called quite late in the app set up process (especially if `actstream` is placed last on the `INSTALLED_APPS` list.)

It allows the following approach:

```python
# in myapp/models.py
from actstream.registry import registry

class MyModel(models.Model):
    ...

registry.register('myapp.MyModel')
```

Rather than:

```python
from actstream.registry import registry

class MyModel(models.Model):
    ...

registry.register(MyModel)
```

Delaying the registration process like this makes the code more stable against circular imports and the issues that people have been experiencing. It isn't a perfect fix and I think in a lot of situations you can get around the import issues in other ways but this does make it more robust so that if people do use this approach they will be less likely to experience an import failure.

The annoying thing is that as I've tried to reproduce a case in which it was failing and this helped, the original case doesn't seem to fail any more. I've no idea what is going on. I'm going to share this as I've got halfway to sharing it a few times now only to be met by something like this. ie. it randomly working again.

Maybe it'll help someone who is otherwise resisting updating to 0.5.1.

Cheers,
Michael