### PR TITLE
Fixed utf8 decoding on Action.timesince function.

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -144,7 +144,7 @@ class Action(models.Model):
         Shortcut for the ``django.utils.timesince.timesince`` function of the
         current timestamp.
         """
-        return djtimesince(self.timestamp, now).encode('utf8').replace(b'\xc2\xa0', b' ').decode()
+        return djtimesince(self.timestamp, now).encode('utf8').replace(b'\xc2\xa0', b' ').decode('utf8')
 
     @models.permalink
     def get_absolute_url(self):


### PR DESCRIPTION
We were working with pip django-activity-stream package, and having some errors of not getting action string properly: they were shown as blank. This seems to be a simple oversight. 
