### PR TITLE
Add test for action_with_%s_as_%s that fails in django1.6

### DIFF
--- a/actstream/tests/test_gfk.py
+++ b/actstream/tests/test_gfk.py
@@ -93,3 +93,8 @@ class GFKManagerTestCase(TestCase):
             (a.id, a.actor, a.target) for a in generic()]
         self.assertEqual(action_actor_targets,
                          action_actor_targets_fetch_generic_target)
+
+        # compare to fetching generic relations via contributed attributes
+        self.assertEqual(
+                list(actions()),
+                list(Action.objects.filter(actions_with_testapp_myuser_as_actor=self.user1)))


### PR DESCRIPTION
I noticed after changing versions to django1.6 that querying on attributes like `action_with_%s_as_%s` not raises a `FieldError`. Since the code to add the attributes is still in `setup_generic_relations` I think this is probably a bug.

https://github.com/justquick/django-activity-stream/issues/220