### PR TITLE
Replace problamatic CharField GFKs with PositiveInterField fields.

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -29,7 +29,7 @@ class Follow(models.Model):
     user = models.ForeignKey(user_model_label, db_index=True)
 
     content_type = models.ForeignKey(ContentType, db_index=True)
-    object_id = models.CharField(max_length=255, db_index=True)
+    object_id = models.PositiveIntegerField(db_index=True)
     follow_object = generic.GenericForeignKey()
     actor_only = models.BooleanField("Only follow actions where "
                                      "the object is the target.", default=True)
@@ -75,7 +75,7 @@ class Action(models.Model):
     """
     actor_content_type = models.ForeignKey(ContentType, related_name='actor',
                                            db_index=True)
-    actor_object_id = models.CharField(max_length=255, db_index=True)
+    actor_object_id = models.PositiveIntegerField(db_index=True)
     actor = generic.GenericForeignKey('actor_content_type', 'actor_object_id')
 
     verb = models.CharField(max_length=255, db_index=True)
@@ -83,13 +83,13 @@ class Action(models.Model):
 
     target_content_type = models.ForeignKey(ContentType, blank=True, null=True,
                                             related_name='target', db_index=True)
-    target_object_id = models.CharField(max_length=255, blank=True, null=True, db_index=True)
+    target_object_id = models.PositiveIntegerField(blank=True, null=True, db_index=True)
     target = generic.GenericForeignKey('target_content_type',
                                        'target_object_id')
 
     action_object_content_type = models.ForeignKey(ContentType, blank=True, null=True,
                                                    related_name='action_object', db_index=True)
-    action_object_object_id = models.CharField(max_length=255, blank=True, null=True, db_index=True)
+    action_object_object_id = models.PositiveIntegerField(blank=True, null=True, db_index=True)
     action_object = generic.GenericForeignKey('action_object_content_type',
                                               'action_object_object_id')
 


### PR DESCRIPTION
Hi,

I just noticed an error that when you try to use any Django feature that joins GFK enabled models with other models (e.g. having GenericRelation defined on that model with some related_query_name), it produces an SQL error (PostgreSQL).

Let's take this example model:

```python
class Post(models.Model):
    content = models.TextField(blank=True, null=True)
    position = models.PositiveSmallIntegerField(default=0, blank=True, editable=False)
    action_set = GenericRelation('actstream.Action', object_id_field='action_object_object_id', content_type_field='action_object_content_type', related_query_name='post')
```

We are using https://docs.djangoproject.com/en/1.8/ref/contrib/contenttypes/#reverse-generic-relations here with a related_query_name defined to help sorting/filtering activity streams based on this generic related model (Post) attributes. At this point, a query like below would produce some SQL error:

```python
target_stream(another_object).order_by('post__position')
```

The error produced, in particular by PostgreSQL backend is:
```
operator does not exist: character varying = integer
```

Further investigation reveals that because you are using CharField for GenericForeignKey's PK/ID part, and because by convention other Django models use PositiveIntegerField for their primary keys, Django's SQL compiler is NOT type casting the JOIN clause. Thus, the JOIN is failing from SQL backend due to an attempt to JOIN by (varchar == int) clause.

I have successfully mitigated this issue by replacing your CharField definitions with PositiveIntegerField definitions. So, please have a look at my commit and let's discuss if there's any compelling reason to stick to CharFields.

Thanks,
Shanto