### PR TITLE
Option for showing/hiding timestamp in action representation

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -110,13 +110,22 @@ class Action(models.Model):
             'target': self.target,
             'timesince': self.timesince()
         }
+
         if self.target:
             if self.action_object:
-                return _('%(actor)s %(verb)s %(action_object)s on %(target)s %(timesince)s ago') % ctx
-            return _('%(actor)s %(verb)s %(target)s %(timesince)s ago') % ctx
-        if self.action_object:
-            return _('%(actor)s %(verb)s %(action_object)s %(timesince)s ago') % ctx
-        return _('%(actor)s %(verb)s %(timesince)s ago') % ctx
+                action_line = '%(actor)s %(verb)s %(action_object)s on %(target)s'
+            else:
+                action_line = '%(actor)s %(verb)s %(target)s'
+        elif self.action_object:
+            action_line = '%(actor)s %(verb)s %(action_object)s'
+        else:
+            action_line = '%(actor)s %(verb)s'
+
+        # Add friendly timestamp in most cases
+        if actstream_settings.SETTINGS.get('SHOW_TIMESTAMP', True):
+            action_line += ' %(timesince)s ago'
+
+        return _(action_line) % ctx
 
     def actor_url(self):
         """

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -58,6 +58,7 @@ Here is an example of what you can set in your ``settings.py``
         'USE_PREFETCH': True,
         'USE_JSONFIELD': True,
         'GFK_FETCH_DEPTH': 1,
+        'SHOW_TIMESTAMP': True,
     }
 
 .. note::
@@ -123,3 +124,11 @@ Number of levels of relations that ``select_related`` will perform.
 Only matters if you are not running ``prefetch_related`` (Django<=1.3).
 
 Defaults to ``0``
+
+
+SHOW_TIMESTAMP
+**************
+
+Set this to ``False`` to not include friendly timestamp in string representation of action.
+
+Defaults to ``True``


### PR DESCRIPTION
There are some cases when the activity stream is rendered, we have different place for showing friendly timestamp of each action (or even not showing it at all). Hence, I think it would be good if we have an option inside ACTSTREAM settings just for deciding to show or hide it within the representation of Action model.

	ACTSTREAM_SETTINGS = {
	    'MANAGER': 'myapp.managers.MyActionManager',
	    'FETCH_RELATIONS': True,
	    'USE_PREFETCH': True,
	    'USE_JSONFIELD': True,
	    'GFK_FETCH_DEPTH': 1,
	    'SHOW_TIMESTAMP': True,
	}