### PR TITLE
Using _meta.app_label for is_installed method

### DIFF
--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -1,4 +1,5 @@
 from inspect import isclass
+import re
 
 import django
 from django.conf import settings
@@ -62,7 +63,7 @@ def is_installed(model_class):
     """
     if django.VERSION[:2] >= (1, 7):
         return model_class._meta.installed
-    return model_class._meta.app_label in settings.INSTALLED_APPS
+    return re.sub(r'\.models.*$', '', model_class.__module__) in settings.INSTALLED_APPS or model_class._meta.app_label in settings.INSTALLED_APPS
 
 
 def validate(model_class, exception_class=ImproperlyConfigured):

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -1,5 +1,4 @@
 from inspect import isclass
-import re
 
 import django
 from django.conf import settings
@@ -63,7 +62,7 @@ def is_installed(model_class):
     """
     if django.VERSION[:2] >= (1, 7):
         return model_class._meta.installed
-    return re.sub(r'\.models.*$', '', model_class.__module__) in settings.INSTALLED_APPS
+    return model_class._meta.app_label in settings.INSTALLED_APPS
 
 
 def validate(model_class, exception_class=ImproperlyConfigured):


### PR DESCRIPTION
Registry breaks if model is located somewhere other than app.models and explicitly bound to app by Meta's `app_label`. And the code just looks a little bit more clear (no need to use `re`).