### PR TITLE
Fixed #258 works with defer

### DIFF
--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -101,6 +101,8 @@ class ActionableModelRegistry(dict):
                 del self[model_class]
 
     def check(self, model_class_or_object):
+        if getattr(model_class_or_object, '_deferred', None):
+            model_class_or_object = model_class_or_object._meta.proxy_for_model
         if not isclass(model_class_or_object):
             model_class_or_object = model_class_or_object.__class__
         model_class = validate(model_class_or_object, RuntimeError)


### PR DESCRIPTION
How would you like the unit test done for this? defer is only on 1.7+.

I could make a new field or a new model. Check if the version is > 1.7, if yes make it defer in the get_queryset function of the manager. Then just make a test that uses that field or model which would fail without this pull and pass with it.