### PR TITLE
Add migrations '0002_remove_action_data'

### DIFF
--- a/actstream/migrations/0002_remove_action_data.py
+++ b/actstream/migrations/0002_remove_action_data.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('actstream', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='action',
+            name='data',
+        ),
+    ]


### PR DESCRIPTION
Hi,

I am using this relation on model ´Notification´.

```
class Notification(models.Model):
    action = models.ForeignKey('actstream.Action')
```

When I run `python manage.py makemigrations` the migration `0002_remove_action_data.py` is generated in module 'actstream'

In production this error occurred

```
django.db.migrations.graph.NodeNotFoundError: Migration notification_user.0001_initial dependencies reference nonexistent parent node ('actstream', '0002_remove_action_data')
```

I guess that field `data` was removed in model `Action` but a migrations was not generated for this change.

Do you think that is the case? The migration `0002_remove_action_data` should be added to the repository?

Thanks.