### PR TITLE
Fix wagtail

### DIFF
--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -26,10 +26,8 @@ def setup_generic_relations(model_class):
                                 'in initialisation. Try moving actstream app to come after the '
                                 'apps which have models to register in the INSTALLED_APPS setting.')
 
-    related_attr_name = 'related_name'
+    related_attr_name = 'related_query_name'
     related_attr_value = 'actions_with_%s' % label(model_class)
-    if django.VERSION[:2] >= (1, 7):
-        related_attr_name = 'related_query_name'
     relations = {}
     for field in ('actor', 'target', 'action_object'):
         attr = '%s_actions' % field
@@ -40,11 +38,10 @@ def setup_generic_relations(model_class):
             related_attr_name: attr_value
         }
         rel = generic.GenericRelation('actstream.Action', **kwargs)
-        rel = rel.contribute_to_class(model_class, attr)
+        # Need to for compatibility with wagtail and perhaps others?
+        rel.auto_created = True
+        rel.contribute_to_class(model_class, attr)
         relations[field] = rel
-
-        # @@@ I'm not entirely sure why this works
-        setattr(Action, attr_value, None)
     return relations
 
 

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -83,11 +83,19 @@ def validate(model_class, exception_class=ImproperlyConfigured):
 
 class ActionableModelRegistry(dict):
 
-    def register(self, *model_classes_or_labels):
+    def register(self, *model_classes_or_labels, **kwargs):
+        """ add_generic_relations defaults to false and will add an optional
+        relationship to registered models. This may cause incompatiblity issues
+        and can be disabled.
+        """
+        add_generic_relations = kwargs.get('add_generic_relations', True)
         for class_or_label in model_classes_or_labels:
             model_class = validate(class_or_label)
             if model_class not in self:
-                self[model_class] = setup_generic_relations(model_class)
+                if add_generic_relations:
+                    self[model_class] = setup_generic_relations(model_class)
+                else:
+                    self[model_class] = []
 
     def unregister(self, *model_classes_or_labels):
         for class_or_label in model_classes_or_labels:

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -38,8 +38,6 @@ def setup_generic_relations(model_class):
             related_attr_name: attr_value
         }
         rel = generic.GenericRelation('actstream.Action', **kwargs)
-        # Need to for compatibility with wagtail and perhaps others?
-        rel.auto_created = True
         rel.contribute_to_class(model_class, attr)
         relations[field] = rel
     return relations


### PR DESCRIPTION
Refactors registry.py a bit.
Removes support for Django<1.7.
Fixes the returned array in setup_generic_relations BUT I'm still not sure what this gets used for.
Adds option to disable setting up the generic relation when registering a model.
Fixes #267 