### PR TITLE
Fix #270: Add Django 1.9 compatibility

### DIFF
--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -3,8 +3,7 @@ from django.utils.encoding import force_text
 
 from actstream import settings
 from actstream.signals import action
-from actstream.actions import action_handler
-from actstream.compat import AppConfig
+from actstream.compat_apps import AppConfig
 
 try:
     from django.db.backends.mysql.base import DatabaseOperations
@@ -23,6 +22,7 @@ class ActstreamConfig(AppConfig):
     name = 'actstream'
 
     def ready(self):
+        from actstream.actions import action_handler
         action.connect(action_handler, dispatch_uid='actstream.models')
         action_class = self.get_model('action')
 

--- a/actstream/compat.py
+++ b/actstream/compat.py
@@ -29,9 +29,3 @@ try:
     get_model = apps.get_model
 except ImportError:
     from django.db.models import get_model
-
-    class AppConfig(object):
-        name = None
-
-        def get_model(self, model_name):
-            return get_model(self.name.split('.')[-1], model_name, only_installed=False)

--- a/actstream/compat_apps.py
+++ b/actstream/compat_apps.py
@@ -1,0 +1,12 @@
+try:
+    from django.apps import AppConfig
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models import get_model
+
+    class AppConfig(object):
+        name = None
+
+        def get_model(self, model_name):
+            return get_model(self.name.split('.')[-1], model_name, only_installed=False)

--- a/actstream/runtests/testapp/apps.py
+++ b/actstream/runtests/testapp/apps.py
@@ -1,4 +1,4 @@
-from actstream.compat import AppConfig
+from actstream.compat_apps import AppConfig
 
 
 class TestappConfig(AppConfig):

--- a/actstream/runtests/testapp_nested/apps.py
+++ b/actstream/runtests/testapp_nested/apps.py
@@ -1,4 +1,4 @@
-from actstream.compat import AppConfig
+from actstream.compat_apps import AppConfig
 
 
 class TestappNestedConfig(AppConfig):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,32,33,34,py,py3}-dj{1.4,1.5,1.6,1.7,1.8}-{sqlite,mysql,postgres}
+envlist = py{26,27,32,33,34,35,py,py3}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-{sqlite,mysql,postgres}
 
 [testenv]
 commands = {envpython} actstream/runtests/manage.py test actstream testapp testapp_nested --noinput
@@ -11,11 +11,12 @@ deps =
     dj1.6: Django>=1.6,<1.7
     dj1.7: Django>=1.7,<1.8
     dj1.8: Django>=1.8,<1.9
-    py{26,27,32,33,34,py,py3}-dj{1.4,1.5,1.6}-{sqlite,mysql,postgres}: South==1.0.2
-    py{26,27,32,33,34}-dj{1.4,1.5,1.6,1.7,1.8}-postgres: psycopg2==2.6
-    py{py,py3}-dj{1.4,1.5,1.6,1.7,1.8}-postgres: psycopg2cffi==2.6.1
-    py{py,26,27}-dj{1.4,1.5,1.6,1.7,1.8}-mysql: MySQL-python==1.2.5
-    py{py3,32,33,34}-dj{1.4,1.5,1.6,1.7,1.8}-mysql: PyMySQL==0.6.6
+    dj1.9: Django>=1.9,<1.10
+    py{26,27,32,33,34,35,py,py3}-dj{1.4,1.5,1.6}-{sqlite,mysql,postgres}: South==1.0.2
+    py{26,27,32,33,34,35}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-postgres: psycopg2==2.6
+    py{py,py3}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-postgres: psycopg2cffi==2.6.1
+    py{py,26,27}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-mysql: MySQL-python==1.2.5
+    py{py3,32,33,34}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-mysql: PyMySQL==0.6.6
 
 setenv =
     mysql: DATABASE_ENGINE=mysql


### PR DESCRIPTION
This seems to work. Refer to #270 to see discussion about what change in Django 1.9 caused this. 

I broke compat.py into compat.py and compat_apps.py, in order to get around the need to import get_model from multiple places, and so we can use AppConfig without running into the same issue we were trying to fix.

Let me know if I can improve this. 