### PR TITLE
Docs: fix link to django-jsonfield project

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -10,7 +10,7 @@ settings.py to enable it.
 
 .. note::
 
-    This feature requires that you have `django-jsonfield <https://github.com/bradjasper/django-jsonfield/>`_ installed
+    This feature requires that you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed
 
 You can send the custom data as extra keyword arguments to the ``action`` signal.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -63,7 +63,7 @@ Install it as you would normally and then modify your settings to use the deprec
 Add extra data to actions
 -------------------------
 
-If you want to use custom data on your actions, then make sure you have `django-jsonfield <https://github.com/bradjasper/django-jsonfield/>`_ installed
+If you want to use custom data on your actions, then make sure you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed
 
 .. code-block:: bash
 


### PR DESCRIPTION
https://github.com/bradjasper/django-jsonfield/ is a different project that's called `jsonfield` in pypi.