### PR TITLE
Remove django less then 1.7 from test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,6 @@ env:
     - TOX_ENV=pypy-dj1.7-sqlite
     - TOX_ENV=py34-dj1.7-sqlite
     - TOX_ENV=py27-dj1.7-sqlite  
-    - TOX_ENV=pypy-dj1.6-sqlite
-    - TOX_ENV=py33-dj1.6-sqlite
-    - TOX_ENV=py26-dj1.6-sqlite
-    - TOX_ENV=pypy-dj1.5-sqlite
-    - TOX_ENV=py33-dj1.5-sqlite
-    - TOX_ENV=py27-dj1.5-sqlite
-    - TOX_ENV=py26-dj1.5-sqlite
-    - TOX_ENV=pypy-dj1.4-sqlite
-    - TOX_ENV=py27-dj1.4-sqlite
-    - TOX_ENV=py26-dj1.4-sqlite
     - TOX_ENV=coverage
 install:
   - pip install tox==2.3.1 coveralls==1.1

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,63 +1,68 @@
-   392	Justin Quick        72.5%
-    25	Chris Beaven        4.6%
-     6	Ben Slavin          1.1%
-     6	Deepak Prakash      1.1%
-     5	jordan              0.9%
-     5	Manuel Aristarán    0.9%
-     4	Wade Williams       0.7%
-     4	Trever Shick        0.7%
-     4	Jason Culverhouse   0.7%
-     4	Alexey Boriskin     0.7%
-     4	Piet Delport        0.7%
-     4	Michael Jones       0.7%
-     3	Bruno Amaral        0.6%
-     3	Nolan Brubaker      0.6%
-     3	Christoph Heer      0.6%
-     3	Josh Ourisman       0.6%
-     2	Tiago Henriques     0.4%
-     2	Artem Khurshudov    0.4%
-     2	Benjamin Kampmann   0.4%
-     2	Chris               0.4%
-     2	David Gouldin       0.4%
-     2	Dmitriy Narkevich   0.4%
-     2	Herman Schaaf       0.4%
-     2	Jocelyn Delalande   0.4%
-     2	Matt Katz           0.4%
-     2	Natan Yellin        0.4%
-     2	Patrick Altman      0.4%
-     2	Paul Collins        0.4%
-     2	Rob Terhaar         0.4%
-     2	Ryan Allen          0.4%
-     2	Steve Ivy           0.4%
-     2	Walter Scheper      0.4%
-     2	artscoop            0.4%
-     2	jbsag               0.4%
-     2	neelesh             0.4%
-     1	Alejandro Seguí     0.2%
-     1	Xavier L            0.2%
-     1	Zbigniew Siciarz    0.2%
-     1	Pedro Alcocer       0.2%
-     1	Pedro Burón         0.2%
-     1	Peter Walker        0.2%
-     1	Bob Cribbs          0.2%
-     1	jpic                0.2%
-     1	laginha             0.2%
-     1	Sandip Agrawal      0.2%
-     1	Santiago Piccinini  0.2%
-     1	joaoxsouls          0.2%
-     1	Tamas Leposa        0.2%
-     1	Aaron Williamson    0.2%
-     1	Tom Clancy          0.2%
-     1	Ben Lopatin         0.2%
-     1	Jannon Frank        0.2%
-     1	Frank Wickström     0.2%
-     1	Jj                  0.2%
-     1	Vineet              0.2%
-     1	JocelynDelalande    0.2%
-     1	Filip Wasilewski    0.2%
-     1	Elf M. Sternberg    0.2%
-     1	Donald Stufft       0.2%
-     1	Aziz M. Bookwala    0.2%
-     1	Michael Bertolacci  0.2%
-     1	Can Burak Cilingir  0.2%
-     1	Bojan Mihelac       0.2%
+   410	Justin Quick          72.7%
+    25	Chris Beaven          4.4%
+     6	Ben Slavin            1.1%
+     6	Deepak Prakash        1.1%
+     5	Manuel Aristarán      0.9%
+     5	jordan                0.9%
+     4	Piet Delport          0.7%
+     4	Trever Shick          0.7%
+     4	Jason Culverhouse     0.7%
+     4	Alexey Boriskin       0.7%
+     4	Wade Williams         0.7%
+     4	Michael Jones         0.7%
+     3	Bruno Amaral          0.5%
+     3	Nolan Brubaker        0.5%
+     3	Christoph Heer        0.5%
+     3	Josh Ourisman         0.5%
+     2	Steve Ivy             0.4%
+     2	Artem Khurshudov      0.4%
+     2	Benjamin Kampmann     0.4%
+     2	Chris                 0.4%
+     2	David Gouldin         0.4%
+     2	Dmitriy Narkevich     0.4%
+     2	Herman Schaaf         0.4%
+     2	Jocelyn Delalande     0.4%
+     2	Matt Katz             0.4%
+     2	Natan Yellin          0.4%
+     2	Patrick Altman        0.4%
+     2	Paul Collins          0.4%
+     2	Rob Terhaar           0.4%
+     2	Ryan Allen            0.4%
+     2	Tiago Henriques       0.4%
+     2	Walter Scheper        0.4%
+     2	artscoop              0.4%
+     2	jbsag                 0.4%
+     2	neelesh               0.4%
+     1	Keith Bussell         0.2%
+     1	Aziz M. Bookwala      0.2%
+     1	Michael Bertolacci    0.2%
+     1	Can Burak Cilingir    0.2%
+     1	Alejandro Seguí       0.2%
+     1	Bojan Mihelac         0.2%
+     1	Xavier L              0.2%
+     1	Zbigniew Siciarz      0.2%
+     1	Pedro Alcocer         0.2%
+     1	Pedro Burón           0.2%
+     1	Peter Walker          0.2%
+     1	Bob Cribbs            0.2%
+     1	jpic                  0.2%
+     1	laginha               0.2%
+     1	Sandip Agrawal        0.2%
+     1	Santiago Piccinini    0.2%
+     1	Aaron Williamson      0.2%
+     1	Tamas Leposa          0.2%
+     1	joaoxsouls            0.2%
+     1	Tom Clancy            0.2%
+     1	Filip Wasilewski      0.2%
+     1	Frank Wickström       0.2%
+     1	Gilberto Magalhães    0.2%
+     1	Hanu Prateek Kunduru  0.2%
+     1	Ben Lopatin           0.2%
+     1	Jannon Frank          0.2%
+     1	Elf M. Sternberg      0.2%
+     1	Jj                    0.2%
+     1	Vineet                0.2%
+     1	JocelynDelalande      0.2%
+     1	Donald Stufft         0.2%
+     1	Denis                 0.2%
+     1	David Burke           0.2%

--- a/actstream/__init__.py
+++ b/actstream/__init__.py
@@ -3,6 +3,6 @@ try:
 except:
     pass
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 __author__ = 'Justin Quick <justquick@gmail.com>'
 default_app_config = 'actstream.apps.ActstreamConfig'

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+0.6.2
+-----
+
+  - Proxy Model support
+  - Brazilian Portuguese translations
+  - Added new migration to remove data field if not being used
+  - URL naming changed for actstream_unfollow_all
+  - Test fix
+
 0.6.1
 -----
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,18 @@
 [tox]
-envlist = py{26,27,32,33,34,35,py,py3}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-{sqlite,mysql,postgres}
+envlist = py{227,33,34,35,py,py3}-dj{1.7,1.8,1.9}-{sqlite,mysql,postgres}
 
 [testenv]
 commands = {envpython} actstream/runtests/manage.py test actstream testapp testapp_nested --noinput
 
 deps =
     django-jsonfield==0.9.13
-    dj1.4: Django>=1.4,<1.5
-    dj1.5: Django>=1.5,<1.6
-    dj1.6: Django>=1.6,<1.7
     dj1.7: Django>=1.7,<1.8
     dj1.8: Django>=1.8,<1.9
     dj1.9: Django>=1.9,<1.10
-    py{26,27,32,33,34,35,py,py3}-dj{1.4,1.5,1.6}-{sqlite,mysql,postgres}: South==1.0.2
-    py{26,27,32,33,34,35}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-postgres: psycopg2==2.6
-    py{py,py3}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-postgres: psycopg2cffi==2.6.1
-    py{py,26,27}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-mysql: MySQL-python==1.2.5
-    py{py3,32,33,34,35}-dj{1.4,1.5,1.6,1.7,1.8,1.9}-mysql: PyMySQL==0.6.6
+    py{27,33,34,35}-dj{1.7,1.8,1.9}-postgres: psycopg2==2.6
+    py{py,py3}-dj{1.7,1.8,1.9}-postgres: psycopg2cffi==2.6.1
+    py{py,27}-dj{1.7,1.8,1.9}-mysql: MySQL-python==1.2.5
+    py{py3,33,34,35}-dj{1.7,1.8,1.9}-mysql: PyMySQL==0.6.6
 
 setenv =
     mysql: DATABASE_ENGINE=mysql

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{227,33,34,35,py,py3}-dj{1.7,1.8,1.9}-{sqlite,mysql,postgres}
+envlist = py{27,33,34,35,py,py3}-dj{1.7,1.8,1.9}-{sqlite,mysql,postgres}
 
 [testenv]
 commands = {envpython} actstream/runtests/manage.py test actstream testapp testapp_nested --noinput


### PR DESCRIPTION
this is intended to get merged in future as 1.8 is the min supported version so its not practical to keep 1.4 1.5 1.6 supports. and python 2.6 3.2
