### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -28,12 +28,12 @@ For Django versions 1.7 or later, you should use `AppConfig <https://docs.django
 
     # myapp/apps.py
     from django.apps import AppConfig
-    from actstream import registry
 
     class MyAppConfig(AppConfig):
         name = 'myapp'
 
         def ready(self):
+            from actstream import registry
             registry.register(self.get_model('MyModel'))
 
     # myapp/__init__.py


### PR DESCRIPTION
Importing actstream.registry inside the ready function prevents the issue in django 1.9 where the error "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet." is raised, preventing from starting the server (as mentioned in issues #270, #272 and #274)