### PR TITLE
Added explicit 'on_delete' arg to ForeignKey fields

### DIFF
--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
 
@@ -33,9 +34,9 @@ class Migration(migrations.Migration):
                 ('timestamp', models.DateTimeField(db_index=True, default=django.utils.timezone.now, help_text='')),
                 ('public', models.BooleanField(db_index=True, default=True, help_text='')),
                 ('data', DataField(blank=True, null=True, help_text='')),
-                ('action_object_content_type', models.ForeignKey(blank=True, null=True, help_text='', related_name='action_object', to='contenttypes.ContentType')),
-                ('actor_content_type', models.ForeignKey(help_text='', related_name='actor', to='contenttypes.ContentType')),
-                ('target_content_type', models.ForeignKey(blank=True, null=True, help_text='', related_name='target', to='contenttypes.ContentType')),
+                ('action_object_content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, blank=True, null=True, help_text='', related_name='action_object', to='contenttypes.ContentType')),
+                ('actor_content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, help_text='', related_name='actor', to='contenttypes.ContentType')),
+                ('target_content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, blank=True, null=True, help_text='', related_name='target', to='contenttypes.ContentType')),
             ],
             options={
                 'ordering': ('-timestamp',),
@@ -48,8 +49,8 @@ class Migration(migrations.Migration):
                 ('object_id', models.CharField(max_length=255, db_index=True, help_text='')),
                 ('actor_only', models.BooleanField(verbose_name='Only follow actions where the object is the target.', default=True, help_text='')),
                 ('started', models.DateTimeField(db_index=True, default=django.utils.timezone.now, help_text='')),
-                ('content_type', models.ForeignKey(help_text='', to='contenttypes.ContentType')),
-                ('user', models.ForeignKey(help_text='', to=settings.AUTH_USER_MODEL)),
+                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, help_text='', to='contenttypes.ContentType')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, help_text='', to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/actstream/models.py
+++ b/actstream/models.py
@@ -26,9 +26,9 @@ class Follow(models.Model):
     """
     Lets a user follow the activities of any specific actor
     """
-    user = models.ForeignKey(user_model_label, db_index=True)
+    user = models.ForeignKey(user_model_label, on_delete=models.CASCADE, db_index=True)
 
-    content_type = models.ForeignKey(ContentType, db_index=True)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, db_index=True)
     object_id = models.CharField(max_length=255, db_index=True)
     follow_object = generic.GenericForeignKey()
     actor_only = models.BooleanField("Only follow actions where "
@@ -74,7 +74,7 @@ class Action(models.Model):
 
     """
     actor_content_type = models.ForeignKey(ContentType, related_name='actor',
-                                           db_index=True)
+                                           on_delete=models.CASCADE, db_index=True)
     actor_object_id = models.CharField(max_length=255, db_index=True)
     actor = generic.GenericForeignKey('actor_content_type', 'actor_object_id')
 
@@ -82,13 +82,15 @@ class Action(models.Model):
     description = models.TextField(blank=True, null=True)
 
     target_content_type = models.ForeignKey(ContentType, blank=True, null=True,
-                                            related_name='target', db_index=True)
+                                            related_name='target',
+                                            on_delete=models.CASCADE, db_index=True)
     target_object_id = models.CharField(max_length=255, blank=True, null=True, db_index=True)
     target = generic.GenericForeignKey('target_content_type',
                                        'target_object_id')
 
     action_object_content_type = models.ForeignKey(ContentType, blank=True, null=True,
-                                                   related_name='action_object', db_index=True)
+                                                   related_name='action_object',
+                                                   on_delete=models.CASCADE, db_index=True)
     action_object_object_id = models.CharField(max_length=255, blank=True, null=True, db_index=True)
     action_object = generic.GenericForeignKey('action_object_content_type',
                                               'action_object_object_id')


### PR DESCRIPTION
Beginning in Django 2.0, the 'on_delete' argument will be required for any
ForeignKey model fields.  The default behavior in Django is to CASCADE delete
a Model when its related field is removed, so I added this definition to the
existing Model fields:
- Follow.user
- Follow.content_type
- Action.actor_content_type
- Action.target_content_type
- Action.action_object_content_type

These changes should be backwards-compatible with any existing installation.
I also added these definitions to the migrations files--though not the
south_migrations (since it's unlikely South would be used in a Django 2.0
installation at this point).

I did this mainly to get rid of the many 'RemovedInDjango20Warning'
deprecation notices in my Django 1.9 installation, but will allow the module
to be compatible with future versions of Django.
