### PR TITLE
Abstract models [WIP]

### DIFF
--- a/actstream/__init__.py
+++ b/actstream/__init__.py
@@ -1,8 +1,39 @@
 try:
+    from actstream.settings import ACTSTREAM_ACTION_MODEL, ACTSTREAM_FOLLOW_MODEL
     from actstream.signals import action
+    from django.apps import apps as django_apps
 except:
     pass
+
 
 __version__ = '0.6.3'
 __author__ = 'Justin Quick <justquick@gmail.com>'
 default_app_config = 'actstream.apps.ActstreamConfig'
+
+
+def get_action_model():
+    """
+    Returns the Action model that is active in this project.
+    """
+    try:
+        return django_apps.get_model(ACTSTREAM_ACTION_MODEL)
+    except ValueError:
+        raise ImproperlyConfigured("ACTSTREAM_ACTION_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "ACTSTREAM_ACTION_MODEL refers to model '%s' that has not been installed" % ACTSTREAM_ACTION_MODEL
+        )
+
+
+def get_follow_model():
+    """
+    Returns the Follow model that is active in this project.
+    """
+    try:
+        return django_apps.get_model(ACTSTREAM_FOLLOW_MODEL)
+    except ValueError:
+        raise ImproperlyConfigured("ACTSTREAM_FOLLOW_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "ACTSTREAM_FOLLOW_MODEL refers to model '%s' that has not been installed" % ACTSTREAM_FOLLOW_MODEL
+        )

--- a/actstream/actions.py
+++ b/actstream/actions.py
@@ -110,7 +110,7 @@ def action_handler(verb, **kwargs):
             setattr(newaction, '%s_object_id' % opt, obj.pk)
             setattr(newaction, '%s_content_type' % opt,
                     ContentType.objects.get_for_model(obj))
-    if settings.USE_JSONFIELD and len(kwargs):
+    if hasattr(newaction, 'data') and len(kwargs):
         newaction.data = kwargs
     newaction.save(force_insert=True)
     return newaction

--- a/actstream/actions.py
+++ b/actstream/actions.py
@@ -4,10 +4,9 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.six import text_type
 from django.contrib.contenttypes.models import ContentType
 
-from actstream import settings
+from actstream import get_action_model, get_follow_model, settings
 from actstream.signals import action
 from actstream.registry import check
-from actstream.compat import get_model
 
 try:
     from django.utils import timezone
@@ -37,7 +36,7 @@ def follow(user, obj, send_action=True, actor_only=True, **kwargs):
         follow(request.user, group, actor_only=False)
     """
     check(obj)
-    instance, created = get_model('actstream', 'follow').objects.get_or_create(
+    instance, created = get_follow_model().objects.get_or_create(
         user=user, object_id=obj.pk,
         content_type=ContentType.objects.get_for_model(obj),
         actor_only=actor_only)
@@ -58,7 +57,7 @@ def unfollow(user, obj, send_action=False):
         unfollow(request.user, other_user)
     """
     check(obj)
-    get_model('actstream', 'follow').objects.filter(
+    get_follow_model().objects.filter(
         user=user, object_id=obj.pk,
         content_type=ContentType.objects.get_for_model(obj)
     ).delete()
@@ -77,7 +76,7 @@ def is_following(user, obj):
         is_following(request.user, group)
     """
     check(obj)
-    return get_model('actstream', 'follow').objects.filter(
+    return get_follow_model().objects.filter(
         user=user, object_id=obj.pk,
         content_type=ContentType.objects.get_for_model(obj)
     ).exists()
@@ -95,7 +94,7 @@ def action_handler(verb, **kwargs):
     if hasattr(verb, '_proxy____args'):
         verb = verb._proxy____args[0]
 
-    newaction = get_model('actstream', 'action')(
+    newaction = get_action_model()(
         actor_content_type=ContentType.objects.get_for_model(actor),
         actor_object_id=actor.pk,
         verb=text_type(verb),

--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -11,12 +11,3 @@ class ActstreamConfig(AppConfig):
     def ready(self):
         from actstream.actions import action_handler
         action.connect(action_handler, dispatch_uid='actstream.models')
-        action_class = self.get_model('action')
-
-        if settings.USE_JSONFIELD:
-            try:
-                from jsonfield.fields import JSONField
-            except ImportError:
-                raise ImproperlyConfigured('You must have django-jsonfield installed '
-                                           'if you wish to use a JSONField on your actions')
-            JSONField(blank=True, null=True).contribute_to_class(action_class, 'data')

--- a/actstream/managers.py
+++ b/actstream/managers.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
 
+from actstream import get_follow_model
 from actstream.gfk import GFKManager
 from actstream.decorators import stream
 from actstream.registry import check
-from actstream.compat import get_model
 
 
 class ActionManager(GFKManager):
@@ -101,7 +101,7 @@ class ActionManager(GFKManager):
             object_content_type = ContentType.objects.get_for_model(obj)
             actors_by_content_type[object_content_type.id].append(obj.pk)
 
-        follow_gfks = get_model('actstream', 'follow').objects.filter(
+        follow_gfks = get_follow_model().objects.filter(
             user=obj).values_list('content_type_id',
                                   'object_id', 'actor_only')
 

--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -38,6 +38,7 @@ class Migration(migrations.Migration):
                 ('target_content_type', models.ForeignKey(blank=True, null=True, help_text='', related_name='target', to='contenttypes.ContentType')),
             ],
             options={
+                'swappable': 'ACTSTREAM_ACTION_MODEL',
                 'ordering': ('-timestamp',),
             },
         ),
@@ -51,6 +52,9 @@ class Migration(migrations.Migration):
                 ('content_type', models.ForeignKey(help_text='', to='contenttypes.ContentType')),
                 ('user', models.ForeignKey(help_text='', to=settings.AUTH_USER_MODEL)),
             ],
+            options={
+                'swappable': 'ACTSTREAM_FOLLOW_MODEL',
+            },
         ),
         migrations.AlterUniqueTogether(
             name='follow',

--- a/actstream/models.py
+++ b/actstream/models.py
@@ -2,12 +2,13 @@ from __future__ import unicode_literals
 
 import django
 from django.apps import apps as django_apps
-from django.db import models
-from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.timesince import timesince as djtimesince
 from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.functional import SimpleLazyObject
+from django.utils.timesince import timesince as djtimesince
+from django.utils.translation import ugettext as _
 
 
 try:
@@ -165,14 +166,14 @@ class Follow(AbstractFollow):
 
 
 # convenient accessors
-actor_stream = Action.objects.actor
-action_object_stream = Action.objects.action_object
-target_stream = Action.objects.target
-user_stream = Action.objects.user
-model_stream = Action.objects.model_actions
-any_stream = Action.objects.any
-followers = Follow.objects.followers
-following = Follow.objects.following
+actor_stream = SimpleLazyObject(lambda: get_action_model().objects.actor)
+action_object_stream = SimpleLazyObject(lambda: get_action_model().objects.action_object)
+target_stream = SimpleLazyObject(lambda: get_action_model().objects.target)
+user_stream = SimpleLazyObject(lambda: get_action_model().objects.user)
+model_stream = SimpleLazyObject(lambda: get_action_model().objects.model_actions)
+any_stream = SimpleLazyObject(lambda: get_action_model().objects.any)
+followers = SimpleLazyObject(lambda: get_follow_model().objects.followers)
+following = SimpleLazyObject(lambda: get_follow_model().objects.following)
 
 
 if django.VERSION[:2] < (1, 7):

--- a/actstream/models.py
+++ b/actstream/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import django
+from django.apps import apps as django_apps
 from django.db import models
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -22,7 +23,7 @@ from actstream.compat import user_model_label, generic
 
 
 @python_2_unicode_compatible
-class Follow(models.Model):
+class AbstractFollow(models.Model):
     """
     Lets a user follow the activities of any specific actor
     """
@@ -37,6 +38,7 @@ class Follow(models.Model):
     objects = FollowManager()
 
     class Meta:
+        abstract = True
         unique_together = ('user', 'content_type', 'object_id')
 
     def __str__(self):
@@ -44,7 +46,7 @@ class Follow(models.Model):
 
 
 @python_2_unicode_compatible
-class Action(models.Model):
+class AbstractAction(models.Model):
     """
     Action model describing the actor acting out a verb (on an optional
     target).
@@ -100,6 +102,7 @@ class Action(models.Model):
     objects = actstream_settings.get_action_manager()
 
     class Meta:
+        abstract = True
         ordering = ('-timestamp', )
 
     def __str__(self):
@@ -149,6 +152,16 @@ class Action(models.Model):
     @models.permalink
     def get_absolute_url(self):
         return 'actstream.views.detail', [self.pk]
+
+
+class Action(AbstractAction):
+    class Meta(AbstractAction.Meta):
+        swappable = 'ACTSTREAM_ACTION_MODEL'
+
+
+class Follow(AbstractFollow):
+    class Meta(AbstractFollow.Meta):
+        swappable = 'ACTSTREAM_FOLLOW_MODEL'
 
 
 # convenient accessors

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.six import string_types
 
 
+from actstream import get_action_model
 from actstream.compat import generic, get_model
 
 
@@ -19,7 +20,7 @@ def setup_generic_relations(model_class):
     """
     Set up GenericRelations for actionable models.
     """
-    Action = get_model('actstream', 'action')
+    Action = get_action_model()
 
     if Action is None:
         raise RegistrationError('Unable get actstream.Action. Potential circular imports '
@@ -39,7 +40,7 @@ def setup_generic_relations(model_class):
             'object_id_field': '%s_object_id' % field,
             related_attr_name: attr_value
         }
-        rel = generic.GenericRelation('actstream.Action', **kwargs)
+        rel = generic.GenericRelation(settings.ACTSTREAM_ACTION_MODEL, **kwargs)
         rel.contribute_to_class(model_class, attr)
         relations[field] = rel
 

--- a/actstream/settings.py
+++ b/actstream/settings.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 
 
+ACTSTREAM_ACTION_MODEL = getattr(settings, 'ACTSTREAM_ACTION_MODEL', 'actstream.Action')
+ACTSTREAM_FOLLOW_MODEL = getattr(settings, 'ACTSTREAM_FOLLOW_MODEL', 'actstream.Follow')
 SETTINGS = getattr(settings, 'ACTSTREAM_SETTINGS', {})
 
 


### PR DESCRIPTION
I just cobbled this together taking inspiration from django.contrib.auth – it's actually working quite well with minimal effort – my apps tests pass with this, the hidden swappable API is neat.

I mostly need input on the changes made and what you want to do about various BC considerations if this is something you'd be interested in merging.
## some thoughts
- [x] AbstractAction
- [x] AbstractFollow
- [x] Django migration handling (swappable handles this)
- [ ] Strip 0002 migration?
- [ ] Scrap JSON support entirely and leave it to developers?
- [ ] South migration handling (no idea... suggestions?)
- [ ] convenient accessors in models (real models aren't available yet... lazy objects?)
- [ ] various other calls to `get_model` that can/should probably go
- [ ] extra kwargs passed to `action.send` currently pile into `data` as per existing implementation - I think as of this work any extra kwargs passed should be assumed to be fields on the model – developers can retain existing behaviour by passing a data dict `data={'some':'thing'}`
## usage example (working my end)

``` py
# settings.py
ACTSTREAM_ACTION_MODEL = 'users.Action'
ACTSTREAM_FOLLOW_MODEL = 'users.Follow'
```

``` py
# users/models.py
from actstream.models import AbstractAction, AbstractFollow
from django.contrib.postgres.fields import JSONField
from django.db import models
from uuid import uuid4


class Action(AbstractAction):
    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
    data = JSONField(default={})

    class Meta(AbstractAction.Meta):
        db_table = 'ras_actions'


class Follow(AbstractFollow):
    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)

    class Meta(AbstractFollow.Meta):
        db_table = 'ras_follows'
```
## migrations

We discussed migrations in the other thread briefly. If you didn't know / remember (I didn't) the way the swappable behaviour works is to default to using the provided migrations. However, if the developer has supplied their own model class, your migrations are totally disabled, and instead they are generated in the developer's app.

What this means moving forward beyond merging this is that anyone using the default model will run any new migrations you write. However, anyone else will simply inherit the new field via abstract model, and will be required to generate their own migration (simply by running `makemigrations`) – thus it's their problem, this is consistent with `django.contrib.auth` and a fairly reasonable behaviour.
## related issues
#304 #306
