### PR TITLE
django.conf.urls.patterns is deprecated in Django 1.8, removed in 1.10

### DIFF
--- a/actstream/urls.py
+++ b/actstream/urls.py
@@ -1,8 +1,8 @@
 import django
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import url, patterns
+    from django.conf.urls.defaults import url
 
 from actstream import feeds, views
 
@@ -57,4 +57,8 @@ urlpatterns = [
 ]
 
 if django.VERSION[:2] < (1, 9):
+    try:
+        from django.conf.urls import patterns
+    except ImportError:
+        from django.conf.urls.defaults import patterns
     urlpatterns = patterns('', *urlpatterns)


### PR DESCRIPTION
This causes an exception in the exception handler in the import
statement at the top of urls.py

This patch moves the `patterns` import statement into the conditional at
the bottom of urls.py that is only evaluated on < 1.9
