### PR TITLE
Changed the render_to_response to render since the prior was deprecated in django 1.10

### DIFF
--- a/actstream/views.py
+++ b/actstream/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render_to_response, get_object_or_404
+import django
+from django.shortcuts import render_to_response, get_object_or_404, render
 from django.template import RequestContext
 from django.http import HttpResponseRedirect, HttpResponse
 
@@ -9,6 +10,8 @@ from django.views.decorators.csrf import csrf_exempt
 from actstream import actions, models, compat
 
 User = compat.get_user_model()
+
+
 
 
 def respond(request, code):
@@ -45,10 +48,11 @@ def stream(request):
     Index page for authenticated user's activity stream. (Eg: Your feed at
     github.com)
     """
-    return render_to_response('actstream/actor.html', {
+    
+    return render(request, 'actstream/actor.html', context={
         'ctype': ContentType.objects.get_for_model(User),
         'actor': request.user, 'action_list': models.user_stream(request.user)
-    }, context_instance=RequestContext(request))
+    })
 
 
 def followers(request, content_type_id, object_id):
@@ -58,9 +62,10 @@ def followers(request, content_type_id, object_id):
     """
     ctype = get_object_or_404(ContentType, pk=content_type_id)
     instance = get_object_or_404(ctype.model_class(), pk=object_id)
-    return render_to_response('actstream/followers.html', {
+
+    return render(request, 'actstream/followers.html', context={
         'followers': models.followers(instance), 'actor': instance
-    }, context_instance=RequestContext(request))
+    })
 
 
 def following(request, user_id):
@@ -68,9 +73,9 @@ def following(request, user_id):
     Returns a list of actors that the user identified by ``user_id`` is following (eg who im following).
     """
     instance = get_object_or_404(User, pk=user_id)
-    return render_to_response('actstream/following.html', {
+    return render(request, 'actstream/following.html', context={
         'following': models.following(instance), 'user': instance
-    }, context_instance=RequestContext(request))
+    })
 
 
 def user(request, username):
@@ -78,19 +83,19 @@ def user(request, username):
     ``User`` focused activity stream. (Eg: Profile page twitter.com/justquick)
     """
     instance = get_object_or_404(User, **{'is_active': True, compat.username_field(): username})
-    return render_to_response('actstream/actor.html', {
+    return render(request, 'actstream/actor.html', context={
         'ctype': ContentType.objects.get_for_model(User),
         'actor': instance, 'action_list': models.user_stream(instance)
-    }, context_instance=RequestContext(request))
+    })
 
 
 def detail(request, action_id):
     """
     ``Action`` detail view (pretty boring, mainly used for get_absolute_url)
     """
-    return render_to_response('actstream/detail.html', {
+    return render(request, 'actstream/detail.html', context={
         'action': get_object_or_404(models.Action, pk=action_id)
-    }, context_instance=RequestContext(request))
+    })
 
 
 def actor(request, content_type_id, object_id):
@@ -100,10 +105,10 @@ def actor(request, content_type_id, object_id):
     """
     ctype = get_object_or_404(ContentType, pk=content_type_id)
     instance = get_object_or_404(ctype.model_class(), pk=object_id)
-    return render_to_response('actstream/actor.html', {
+    return render(request, 'actstream/actor.html', context={
         'action_list': models.actor_stream(instance), 'actor': instance,
         'ctype': ctype
-    }, context_instance=RequestContext(request))
+    })
 
 
 def model(request, content_type_id):
@@ -113,7 +118,7 @@ def model(request, content_type_id):
     """
     ctype = get_object_or_404(ContentType, pk=content_type_id)
     model_class = ctype.model_class()
-    return render_to_response('actstream/actor.html', {
+    return render(request, 'actstream/actor.html', context={
         'action_list': models.model_stream(model_class), 'ctype': ctype,
         'actor': model_class
-    }, context_instance=RequestContext(request))
+    })

--- a/actstream/views.py
+++ b/actstream/views.py
@@ -1,4 +1,3 @@
-import django
 from django.shortcuts import render_to_response, get_object_or_404, render
 from django.template import RequestContext
 from django.http import HttpResponseRedirect, HttpResponse


### PR DESCRIPTION
After doing some checking in the official release notes in django 1.10, I realized that the context_instance for both render_to_response and render were both deprecated. Since 
`render(request, context, template_name)`
 is technically the same as 
`render_to_response(template_name,  {...}, context_instance=RequestContext(request))`
It is the best substitute in this case.