### PR TITLE
Integrate jsonfield_compat

### DIFF
--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -15,10 +15,12 @@ class ActstreamConfig(AppConfig):
 
         if settings.USE_JSONFIELD:
             try:
-                from jsonfield.fields import JSONField
+                from jsonfield_compat import JSONField, register_app
             except ImportError:
                 raise ImproperlyConfigured(
-                    'You must have django-jsonfield installed '
+                    'You must have django-jsonfield-compat installed '
                     'if you wish to use a JSONField on your actions'
                 )
             JSONField(blank=True, null=True).contribute_to_class(action_class, 'data')
+
+            register_app(self)

--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from actstream.settings import USE_JSONFIELD
 
 if USE_JSONFIELD:
-    from jsonfield.fields import JSONField as DataField
+    from jsonfield_compat.fields import JSONField as DataField
 else:
     DataField = models.TextField
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 Django>=1.7
 Sphinx>=1.2.2
 git+https://github.com/justquick/alabaster.git#egg=alabaster
-django-jsonfield>=2.0.1
+django-jsonfield==1.0.1
+django-jsonfield-compat==0.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py{27,33,34,35,36}-dj{1.7,1.8,1.9,1.10,1.11}-{sqlite,mysql,postgres}
 commands = {envpython} actstream/runtests/manage.py test actstream testapp testapp_nested --noinput
 
 deps =
-    django-jsonfield>=2.0.1
+    django-jsonfield>=1.0.1
     dj1.7: Django>=1.7,<1.8
     dj1.8: Django>=1.8,<1.9
     dj1.9: Django>=1.9,<1.10
@@ -26,7 +26,7 @@ commands =
     coverage run --include="actstream*" --omit="*migrations*" actstream/runtests/manage.py test actstream testapp testapp_nested --noinput
 basepython = python2.7
 deps =
-    django-jsonfield>=2.0.1
+    django-jsonfield>=1.0.1
     Django>=1.8,<2.0
     coveralls>=1.1
     coverage>=4.0.3


### PR DESCRIPTION
This commit integrates django-jsonfield-compat, which is a solution to #294.

After using this branch, add
```
USE_NATIVE_JSONFIELD = True
```
to your project's settings, and then run `python manage.py migrate`.

This will update all JSONFields to be a native JSONField type, assuming you're using PostgreSQL and Django >= 1.9. You can switch everything back by changing the above setting to `False`, just be sure to run migrate again afterwards.