### PR TITLE
Send full 1.11 compatible context into templates

### DIFF
--- a/actstream/templatetags/activity_tags.py
+++ b/actstream/templatetags/activity_tags.py
@@ -94,7 +94,7 @@ class DisplayAction(AsNode):
             'actstream/%s/action.html' % action_instance.verb.replace(' ', '_'),
             'actstream/action.html',
         ]
-        return render_to_string(templates, {'action': action_instance})
+        return render_to_string(templates, context.flatten())
 
 
 def display_action(parser, token):


### PR DESCRIPTION
Since `context` contains `'action'` at this point, please do not leave out the rest of the context as it may be necessary for custom `actstream/action.html` templates.