### PR TITLE
Document using native JSONField.

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -6,11 +6,15 @@ Adding Custom Data to your Actions
 As of v0.4.4, django-activity-stream now supports adding custom data to any Actions you generate.
 This uses a ``data`` JSONField on every Action where you can insert and delete values at will.
 This behavior is disabled by default but just set ``ACTSTREAM_SETTINGS['USE_JSONFIELD'] = True`` in your
-settings.py to enable it.
+settings.py to enable it. If you're running Django >= 1.9 and you'd like to use the JSONField included
+with Django, set `USE_NATIVE_JSONFIELD = True` in your settings file. See
+`django-jsonfield-compat <https://github.com/kbussell/django-jsonfield-compat#installation>`_ for more
+information.
+
 
 .. note::
 
-    This feature requires that you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed
+    This feature requires that you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed.
 
 You can send the custom data as extra keyword arguments to the ``action`` signal.
 


### PR DESCRIPTION
Added a link to django-jsonfield-compat so that users can see how to use Django's native JSONField implementation too.