### PR TITLE
Add support for django-mysql's JSONField as alternative implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ script:
   - tox
 addons:
   postgresql: "9.5"
+  apt:
+    sources:
+      - mysql-5.7-trusty
+    packages:
+      - mysql-server
+      - mysql-client
 notifications:
   email: false
 after_success:

--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-from django.core.exceptions import ImproperlyConfigured
 
 from actstream import settings
 from actstream.signals import action
@@ -14,12 +13,8 @@ class ActstreamConfig(AppConfig):
         action_class = self.get_model('action')
 
         if settings.USE_JSONFIELD:
-            try:
-                from jsonfield_compat import JSONField, register_app
-            except ImportError:
-                raise ImproperlyConfigured(
-                    'You must have django-jsonfield and django-jsonfield-compat '
-                    'installed if you wish to use a JSONField on your actions'
-                )
-            JSONField(blank=True, null=True).contribute_to_class(action_class, 'data')
+            from actstream.jsonfield import JSONField, register_app
+            JSONField(blank=True, null=True).contribute_to_class(
+                action_class, 'data'
+            )
             register_app(self)

--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -13,8 +13,8 @@ class ActstreamConfig(AppConfig):
         action_class = self.get_model('action')
 
         if settings.USE_JSONFIELD:
-            from actstream.jsonfield import JSONField, register_app
-            JSONField(blank=True, null=True).contribute_to_class(
+            from actstream.jsonfield import DataField, register_app
+            DataField(blank=True, null=True).contribute_to_class(
                 action_class, 'data'
             )
             register_app(self)

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -2,16 +2,18 @@
 
 Decide on a JSONField implementation based on available packages.
 
-There are three possible options, preferred in the following order:
+There are two possible options, preferred in the following order:
   - JSONField from django-jsonfield with django-jsonfield-compat
   - JSONField from django-mysql (needs MySQL 5.7+)
-  - TextField from django
 
 Raises an ImportError if USE_JSONFIELD is True but none of these are
-installed. Falls back to a simple TextField if USE_JSONFIELD is False.
+installed.
+
+Falls back to a simple Django TextField if USE_JSONFIELD is False,
+however that field will be removed by migration 0002 directly
+afterwards.
 
 '''
-
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
 

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -1,4 +1,4 @@
-"""
+'''
 
 Decide on a JSONField implementation based on available packages.
 
@@ -10,7 +10,7 @@ There are three possible options, preferred in the following order:
 Raises an ImportError if USE_JSONFIELD is True but none of these are
 installed. Falls back to a simple TextField if USE_JSONFIELD is False.
 
-"""
+'''
 
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
@@ -18,24 +18,26 @@ from django.core.exceptions import ImproperlyConfigured
 from actstream.settings import USE_JSONFIELD
 
 
-__all__ = ("DataField", "JSONField", "register_app")
+__all__ = ('DataField', 'JSONField', 'register_app')
 
 
 if USE_JSONFIELD:
     try:
         from jsonfield_compat import JSONField, register_app
-    except ImportError:
-        from django_mysql.models import JSONField
+    except ImportError as err:
+        try:
+            from django_mysql.models import JSONField
 
-        def register_app(app):
-            pass
+            def register_app(app):
+                pass
 
-    except ImportError:
-        raise ImproperlyConfigured(
-            'You must either have django-jsonfield and django-jsonfield-compat'
-            ' or django-mysql installed if you wish to use a JSONField on your'
-            ' actions'
-        )
+        except ImportError:
+            raise ImproperlyConfigured(
+                'You must either install django-jsonfield + '
+                'django-jsonfield-compat, or django-mysql as an '
+                'alternative, if you wish to use a JSONField on your '
+                'actions'
+            )
     DataField = JSONField
 else:
     DataField = models.TextField

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -35,13 +35,7 @@ if USE_JSONFIELD:
     except ImportError as err:
         try:
             from django_mysql.models import JSONField
-            # The JSONField comes with a method to check if the mysql
-            # version supports it. We use it here to decide whether we
-            # can really use the field implementation here instead of
-            # failing later.
-            errors = JSONField()._check_mysql_version()
-            if not errors:
-                DataField = JSONField
+            DataField = JSONField
 
         except ImportError:
             raise ImproperlyConfigured(

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -1,0 +1,41 @@
+"""
+
+Decide on a JSONField implementation based on available packages.
+
+There are three possible options, preferred in the following order:
+  - JSONField from django-jsonfield with django-jsonfield-compat
+  - JSONField from django-mysql
+  - TextField from django
+
+Raises an ImportError if USE_JSONFIELD is True but none of these are
+installed. Falls back to a simple TextField if USE_JSONFIELD is False.
+
+"""
+
+from django.db import models
+from django.core.exceptions import ImproperlyConfigured
+
+from actstream.settings import USE_JSONFIELD
+
+
+__all__ = ("DataField", "JSONField", "register_app")
+
+
+if USE_JSONFIELD:
+    try:
+        from jsonfield_compat import JSONField, register_app
+    except ImportError:
+        from django_mysql.models import JSONField
+
+        def register_app(app):
+            pass
+
+    except ImportError:
+        raise ImproperlyConfigured(
+            'You must either have django-jsonfield and django-jsonfield-compat'
+            ' or django-mysql installed if you wish to use a JSONField on your'
+            ' actions'
+        )
+    DataField = JSONField
+else:
+    DataField = models.TextField

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -18,18 +18,30 @@ from django.core.exceptions import ImproperlyConfigured
 from actstream.settings import USE_JSONFIELD
 
 
-__all__ = ('DataField', 'JSONField', 'register_app')
+__all__ = ('DataField', 'register_app')
 
+
+def register_app(app):
+    """Noop unless django-jsonfield-compat overwrites it."""
+    pass
+
+
+DataField = models.TextField
 
 if USE_JSONFIELD:
     try:
         from jsonfield_compat import JSONField, register_app
+        DataField = JSONField
     except ImportError as err:
         try:
             from django_mysql.models import JSONField
-
-            def register_app(app):
-                pass
+            # The JSONField comes with a method to check if the mysql
+            # version supports it. We use it here to decide whether we
+            # can really use the field implementation here instead of
+            # failing later.
+            errors = JSONField()._check_mysql_version()
+            if not errors:
+                DataField = JSONField
 
         except ImportError:
             raise ImproperlyConfigured(
@@ -38,8 +50,5 @@ if USE_JSONFIELD:
                 'alternative, if you wish to use a JSONField on your '
                 'actions'
             )
-    DataField = JSONField
-else:
-    DataField = models.TextField
 
 print('JSONField implementation is: {}'.format(DataField))

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -41,3 +41,5 @@ if USE_JSONFIELD:
     DataField = JSONField
 else:
     DataField = models.TextField
+
+print('JSONField implementation is: {}'.format(DataField))

--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -4,7 +4,7 @@ Decide on a JSONField implementation based on available packages.
 
 There are three possible options, preferred in the following order:
   - JSONField from django-jsonfield with django-jsonfield-compat
-  - JSONField from django-mysql
+  - JSONField from django-mysql (needs MySQL 5.7+)
   - TextField from django
 
 Raises an ImportError if USE_JSONFIELD is True but none of these are

--- a/actstream/migrations/0001_initial.py
+++ b/actstream/migrations/0001_initial.py
@@ -6,12 +6,7 @@ import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
 
-from actstream.settings import USE_JSONFIELD
-
-if USE_JSONFIELD:
-    from jsonfield_compat.fields import JSONField as DataField
-else:
-    DataField = models.TextField
+from actstream.jsonfield import DataField
 
 
 class Migration(migrations.Migration):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,8 +12,9 @@ Changelog
   - use render function instead of depricated render_to_response
   - upgrade package depedencies
   - django 1.11, 2.0 and 2.1 support added
-  - Code cean ups
-  
+  - Code clean ups
+  - Add optional support for django-mysql's JSONField
+
 0.6.5
 -----
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -7,14 +7,14 @@ As of v0.4.4, django-activity-stream now supports adding custom data to any Acti
 This uses a ``data`` JSONField on every Action where you can insert and delete values at will.
 This behavior is disabled by default but just set ``ACTSTREAM_SETTINGS['USE_JSONFIELD'] = True`` in your
 settings.py to enable it. If you're running Django >= 1.9 and you'd like to use the JSONField included
-with Django, set `USE_NATIVE_JSONFIELD = True` in your settings file. See
-`django-jsonfield-compat <https://github.com/kbussell/django-jsonfield-compat#installation>`_ for more
-information.
-
+with Django, set ``USE_NATIVE_JSONFIELD = True`` in your settings file.
 
 .. note::
 
-    This feature requires that you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed.
+  Multiple implementations of the JSONField are supported, depending on which packages are installed:
+
+  - The default and preferred implementation is used by installing **both** `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ and `django-jsonfield-compat <https://github.com/kbussell/django-jsonfield-compat>`_. This is also allowing to use Django's native JSONField as described above.
+  - Alternatively you can install **only** `django-mysql <https://github.com/adamchainz/django-mysql>`_ (*requires MySQL 5.7+*) to use its JSONField. Make sure the packages above are **not installed**, as they would be preferred. This can be useful when you are using it already and want to use the same field for actstream.
 
 You can send the custom data as extra keyword arguments to the ``action`` signal.
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -14,7 +14,8 @@ with Django, set ``USE_NATIVE_JSONFIELD = True`` in your settings file.
   Multiple implementations of the JSONField are supported, depending on which packages are installed:
 
   - The default and preferred implementation is used by installing **both** `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ and `django-jsonfield-compat <https://github.com/kbussell/django-jsonfield-compat>`_. This is also allowing to use Django's native JSONField as described above.
-  - Alternatively you can install **only** `django-mysql <https://github.com/adamchainz/django-mysql>`_ (*requires MySQL 5.7+*) to use its JSONField. Make sure the packages above are **not installed**, as they would be preferred. This can be useful when you are using it already and want to use the same field for actstream.
+
+  - Alternatively you can install **only** `django-mysql <https://github.com/adamchainz/django-mysql>`_ (*requires MySQL 5.7+*) to use its JSONField. Make sure the packages above are **not installed**, as they would be preferred. This can be useful when you are using django-mysql already and want to use the same field for actstream.
 
 You can send the custom data as extra keyword arguments to the ``action`` signal.
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ deps =
     postgres,sqlite: django-jsonfield-compat>=0.4.4
     postgres: psycopg2-binary>=2.6
 
-
 setenv =
     mysql: DATABASE_ENGINE=django.db.backends.mysql
     postgres: DATABASE_ENGINE=django.db.backends.postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     django21: Django>=2.1<2.2
     postgres: psycopg2-binary>=2.6
     py{27}-{django111}-mysql: mysqlclient>=1.3.13
-    py{34,35,36}-{django111,django20}-mysql: mysqlclient>=1.3.13
-    py{35,36}-{django21}-mysql: mysqlclient>=1.3.13
+    py{34,35,36,37}-{django111,django20}-mysql: mysqlclient>=1.3.13
+    py{35,36,37}-{django21}-mysql: mysqlclient>=1.3.13
 
 setenv =
     mysql: DATABASE_ENGINE=django.db.backends.mysql

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,15 @@ commands = coverage run runtests/manage.py test -v3 --noinput actstream testapp 
 
 deps =
     coverage>=4.5.1
-    django-jsonfield>=1.0.1
-    django-jsonfield-compat>=0.4.4
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1<2.2
+    mysql: mysqlclient>=1.3.13
+    mysql: django-mysql>=2.4.1
+    postgres,sqlite: django-jsonfield>=1.0.1
+    postgres,sqlite: django-jsonfield-compat>=0.4.4
     postgres: psycopg2-binary>=2.6
-    py{27}-{django111}-mysql: mysqlclient>=1.3.13
-    py{34,35,36,37}-{django111,django20}-mysql: mysqlclient>=1.3.13
-    py{35,36,37}-{django21}-mysql: mysqlclient>=1.3.13
+
 
 setenv =
     mysql: DATABASE_ENGINE=django.db.backends.mysql


### PR DESCRIPTION
## What
This PR adds optional support for **django-mysql**'s [ JSONField](https://django-mysql.readthedocs.io/en/latest/model_fields/json_field.html) (supported by MySQL **5.7**+) to be used instead of the already supported [django-jsonfield](https://github.com/dmkoch/django-jsonfield) and [Django TextField](https://docs.djangoproject.com/en/2.1/ref/models/fields/#django.db.models.TextField) fallback.

## Why
We are using MySQL and django-mysql's JSONField already and would like to use this library without having to rely on a different JSONField implementation. See https://github.com/justquick/django-activity-stream/issues/415

## How
The new `actstream.jsonfield` module is responsible to choose a suitable `JSONField` implementation on startup:
- `USE_JSONFIELD = True` and `django-jsonfield` + `django-jsonfield-compat` installed: Use that.
- `USE_JSONFIELD = True` and `django-mysql` installed: Use that instead.
- `USE_JSONFIELD = False`: `TextField` Fallback is used.

A debug print like `JSONField implementation is: <class 'django_mysql.models.fields.json.JSONField'>` is done on startup to be able to manually check whether the correct implementation is chosen.

## Testing

There already is a test named `TestAppTests.test_jsonfield()` that checks that attaching data to the `JSONField` works as intented, making that pass is the goal.

I have updated the `tox` configuration to use `django-mysql` for the sql environments instead of `django-jsonfield`. Please see https://tox.readthedocs.io/en/latest/config.html#complex-factor-conditions for syntax.

I have done local test runs with Python 2.7 and 3.7 against Django 1.11 and 2.1 using SQLite and MySQL 5.7:
```
tox -e py27-django111-mysql
tox -e py27-django111-sqlite
tox -e py27-django21-mysql
tox -e py27-django21-sqlite
tox -e py37-django111-mysql
tox -e py37-django111-sqlite
tox -e py37-django21-mysql
tox -e py37-django21-sqlite
```