### PR TITLE
Filter user stream by follow flag

### DIFF
--- a/actstream/managers.py
+++ b/actstream/managers.py
@@ -81,7 +81,7 @@ class ActionManager(GFKManager):
             ), **kwargs)
 
     @stream
-    def user(self, obj, with_user_activity=False, **kwargs):
+    def user(self, obj, with_user_activity=False, follow_flag=None, **kwargs):
         """Create a stream of the most recent actions by objects that the user is following."""
         q = Q()
         qs = self.public()
@@ -98,6 +98,9 @@ class ActionManager(GFKManager):
             )
 
         follows = apps.get_model('actstream', 'follow').objects.filter(user=obj)
+        if follow_flag:
+            follows = follows.filter(flag=follow_flag)
+            
         content_types = ContentType.objects.filter(
             pk__in=follows.values('content_type_id')
         )

--- a/actstream/tests/test_activity.py
+++ b/actstream/tests/test_activity.py
@@ -93,6 +93,11 @@ class ActivityTestCase(DataTestCase):
                             ['CoolGroup responded to admin: '
                              'Sweet Group!... %s ago' % self.timesince])
 
+    def test_stream_with_flag(self):
+        self.assertSetEqual(user_stream(self.user4, follow_flag='blacklisting'), [
+            'Three liked actstream %s ago' % self.timesince
+        ])
+
     def test_stream_stale_follows(self):
         """
         user_stream() should ignore Follow objects with stale actor


### PR DESCRIPTION
Hi! 
I met a use case in which it would be useful to get a user stream associated with a particular follow `flag`. For instance to get all the actions concerning an object that a user is _watching_ but not _liking_.
Note that if a user a following an object with two different flags, and we only query for one of them, we will get back all the actions of the followed object. But this is an expected behaviour since the user is following the object anyways. Obviously, actions can't be linked backed to following flags.

This is a quite simple change. I also added a test.

I would be happy to discuss any remark!