### PR TITLE
Remove print statement from jsonfield

### DIFF
--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -46,5 +46,3 @@ if USE_JSONFIELD:
                 'alternative, if you wish to use a JSONField on your '
                 'actions'
             )
-
-print('JSONField implementation is: {}'.format(DataField))


### PR DESCRIPTION
Removes an unnecessary print statement that is cluttering up the console on app startup. 