### PR TITLE
Remove message "JSONField implementation is: ..."

### DIFF
--- a/actstream/jsonfield.py
+++ b/actstream/jsonfield.py
@@ -46,5 +46,3 @@ if USE_JSONFIELD:
                 'alternative, if you wish to use a JSONField on your '
                 'actions'
             )
-
-print('JSONField implementation is: {}'.format(DataField))


### PR DESCRIPTION
This message is shown every time you run any command from terminal and I suppose it's not that important and it distracts developers from useful information.

e.g. there's output from `python manage.py makemigrations`:

```
JSONField implementation is: <class 'jsonfield.fields.JSONField'>
No changes detected
```

P.S. If this message remains, maybe there should be name of the package included like "django-activity-stream: JSONField implementation is: " or something like that. Because it wasn't clear for me what package it's coming from.