### PR TITLE
Remove duplicate rows（`now = timezone.now` # L18，L21 & -L27）

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -24,8 +24,6 @@ except ImportError:
 from actstream import settings as actstream_settings
 from actstream.managers import FollowManager
 
-now = timezone.now
-
 
 class Follow(models.Model):
     """


### PR DESCRIPTION
```
try:
    from django.utils import timezone
    now = timezone.now # L18
except ImportError:
    from datetime import datetime
    now = datetime.now # L21
```
and  `now = timezone.now` # L27 should be removed