### PR TITLE
Remove line importing python_2_unicode_compatible

### DIFF
--- a/actstream/models.py
+++ b/actstream/models.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db import models
 from django.utils.translation import ugettext as _
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timesince import timesince as djtimesince
 from django.contrib.contenttypes.models import ContentType
 


### PR DESCRIPTION
Dear all,

Could you please fix that line? The function "python_2_unicode_compatible", which was part of "django.utils.encoding", seems to have been moved to "six". https://stackoverflow.com/a/43640425

The following error is thrown when Django (3.0.0) tries to load actstream:
```
File "/usr/local/lib/python3.6/site-packages/actstream/models.py", line 7, in <module>
  from django.utils.encoding import python_2_unicode_compatible
ImportError: cannot import name 'python_2_unicode_compatible'
```

Best regards,
Ricardo Rodriguez.