### PR TITLE
Remove Python 2 compatibility APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: python
 cache: pip
 python:
-  - 3.5
   - 3.6
+  - 3.7
 env:
-  - DJANGO=1.11 DATABASE=mysql
-  - DJANGO=1.11 DATABASE=postgresql
-  - DJANGO=1.11 DATABASE=sqlite
-  - DJANGO=2.1 DATABASE=mysql
-  - DJANGO=2.1 DATABASE=postgresql
   - DJANGO=2.2 DATABASE=mysql
   - DJANGO=2.2 DATABASE=postgresql
+  - DJANGO=3.0 DATABASE=mysql
+  - DJANGO=3.0 DATABASE=postgresql
 matrix:
   fast_finish: true
 

--- a/actstream/actions.py
+++ b/actstream/actions.py
@@ -1,19 +1,11 @@
 from django.apps import apps
 from django.utils.translation import ugettext_lazy as _
-from django.utils.six import text_type
+from django.utils.timezone import now
 from django.contrib.contenttypes.models import ContentType
 
 from actstream import settings
 from actstream.signals import action
 from actstream.registry import check
-
-try:
-    from django.utils import timezone
-
-    now = timezone.now
-except ImportError:
-    import datetime
-    now = datetime.datetime.now
 
 
 def follow(user, obj, send_action=True, actor_only=True, flag='', **kwargs):
@@ -125,7 +117,7 @@ def action_handler(verb, **kwargs):
     newaction = apps.get_model('actstream', 'action')(
         actor_content_type=ContentType.objects.get_for_model(actor),
         actor_object_id=actor.pk,
-        verb=text_type(verb),
+        verb=str(verb),
         public=bool(kwargs.pop('public', True)),
         description=kwargs.pop('description', None),
         timestamp=kwargs.pop('timestamp', now())

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -45,7 +45,7 @@ class AbstractActivityStream(object):
         if date is None:
             date = action.timestamp
         date = datetime_safe.new_datetime(date).strftime('%Y-%m-%d')
-        return 'tag:%s,%s:%s' % (Site.objects.get_current().domain, date,
+        return 'tag:{},{}:{}'.format(Site.objects.get_current().domain, date,
                                  self.get_url(action, obj, False))
 
     def get_url(self, action, obj=None, domain=True):

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -6,16 +6,11 @@ from django.utils.feedgenerator import Atom1Feed, rfc3339_date
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.syndication.views import Feed, add_domain
 from django.contrib.sites.models import Site
-from django.utils.encoding import force_text
-from django.utils.six import text_type
+from django.utils.encoding import force_str
 from django.utils import datetime_safe
 from django.views.generic import View
 from django.http import HttpResponse, Http404
-
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
+from django.urls import reverse
 
 from actstream.models import Action, model_stream, user_stream, any_stream
 
@@ -79,7 +74,7 @@ class AbstractActivityStream(object):
             'verb': action.verb,
             'published': rfc3339_date(action.timestamp),
             'actor': self.format_actor(action),
-            'title': text_type(action),
+            'title': str(action),
         }
         if action.description:
             item['content'] = action.description
@@ -98,7 +93,7 @@ class AbstractActivityStream(object):
             'id': self.get_uri(action, obj),
             'url': self.get_url(action, obj),
             'objectType': ContentType.objects.get_for_model(obj).name,
-            'displayName': text_type(obj)
+            'displayName': str(obj)
         }
 
     def format_actor(self, action):
@@ -203,7 +198,7 @@ class ActivityStreamsBaseFeed(AbstractActivityStream, Feed):
 
     def item_description(self, action):
         if action.description:
-            return force_text(action.description)
+            return force_str(action.description)
 
     def items(self, obj):
         return self.get_stream()(obj)[:30]

--- a/actstream/gfk.py
+++ b/actstream/gfk.py
@@ -1,10 +1,7 @@
 from django.db.models import Manager
 from django.db.models.query import QuerySet, EmptyQuerySet
 from django import VERSION as DJANGO_VERSION
-try:
-    from django.contrib.contenttypes.fields import GenericForeignKey
-except ImportError:
-    from django.contrib.contenttypes.generic import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey
 
 from actstream import settings
 
@@ -34,12 +31,7 @@ class GFKQuerySet(QuerySet):
         if not settings.FETCH_RELATIONS:
             return qs
 
-        # Backward compatibility patch for
-        # Django versions lower than 1.11.x
-        if DJANGO_VERSION >= (1, 11):
-            private_fields = self.model._meta.private_fields
-        else:
-            private_fields = self.model._meta.virtual_fields
+        private_fields = self.model._meta.virtual_fields
 
         gfk_fields = [g for g in private_fields if isinstance(g, GenericForeignKey)]
 
@@ -49,14 +41,7 @@ class GFKQuerySet(QuerySet):
         return qs.prefetch_related(*[g.name for g in gfk_fields])
 
     def _clone(self, klass=None, **kwargs):
-        if DJANGO_VERSION >= (2, 0):
-            return super(GFKQuerySet, self)._clone()
-
-        for name in ['subclasses', '_annotated']:
-            if hasattr(self, name):
-                kwargs[name] = getattr(self, name)
-
-        return super(GFKQuerySet, self)._clone(**kwargs)
+        return super(GFKQuerySet, self)._clone()
 
     def none(self):
         clone = self._clone({'klass': EmptyGFKQuerySet})

--- a/actstream/gfk.py
+++ b/actstream/gfk.py
@@ -31,7 +31,7 @@ class GFKQuerySet(QuerySet):
         if not settings.FETCH_RELATIONS:
             return qs
 
-        private_fields = self.model._meta.virtual_fields
+        private_fields = self.model._meta.private_fields
 
         gfk_fields = [g for g in private_fields if isinstance(g, GenericForeignKey)]
 

--- a/actstream/models.py
+++ b/actstream/models.py
@@ -39,7 +39,7 @@ class Follow(models.Model):
         unique_together = ('user', 'content_type', 'object_id', 'flag')
 
     def __str__(self):
-        return '%s -> %s : %s' % (self.user, self.follow_object, self.flag)
+        return '{} -> {} : {}'.format(self.user, self.follow_object, self.flag)
 
 
 class Action(models.Model):

--- a/actstream/models.py
+++ b/actstream/models.py
@@ -6,19 +6,8 @@ from django.db import models
 from django.utils.translation import ugettext as _
 from django.utils.timesince import timesince as djtimesince
 from django.contrib.contenttypes.models import ContentType
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
-
-try:
-    from django.utils import timezone
-    now = timezone.now
-except ImportError:
-    from datetime import datetime
-    now = datetime.now
-
+from django.urls import reverse
+from django.utils.timezone import now
 
 from actstream import settings as actstream_settings
 from actstream.managers import FollowManager

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -5,7 +5,6 @@ from django.apps import apps
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db.models.base import ModelBase
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.six import string_types
 
 
 class RegistrationError(Exception):
@@ -63,7 +62,7 @@ def is_installed(model_class):
 
 
 def validate(model_class, exception_class=ImproperlyConfigured):
-    if isinstance(model_class, string_types):
+    if isinstance(model_class, str):
         model_class = apps.get_model(*model_class.split('.'))
     if not isinstance(model_class, ModelBase):
         raise exception_class(

--- a/actstream/registry.py
+++ b/actstream/registry.py
@@ -30,7 +30,7 @@ def setup_generic_relations(model_class):
     relations = {}
     for field in ('actor', 'target', 'action_object'):
         attr = '%s_actions' % field
-        attr_value = '%s_as_%s' % (related_attr_value, field)
+        attr_value = '{}_as_{}'.format(related_attr_value, field)
         kwargs = {
             'content_type_field': '%s_content_type' % field,
             'object_id_field': '%s_object_id' % field,
@@ -50,7 +50,7 @@ def label(model_class):
         model_name = model_class._meta.model_name
     else:
         model_name = model_class._meta.module_name
-    return '%s_%s' % (model_class._meta.app_label, model_name)
+    return '{}_{}'.format(model_class._meta.app_label, model_name)
 
 
 def is_installed(model_class):

--- a/actstream/templatetags/activity_tags.py
+++ b/actstream/templatetags/activity_tags.py
@@ -1,11 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.template import Variable, Library, Node, TemplateSyntaxError
 from django.template.loader import render_to_string
-
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
+from django.urls import reverse
 
 from actstream.models import Follow, Action
 

--- a/actstream/tests/base.py
+++ b/actstream/tests/base.py
@@ -5,17 +5,12 @@ from inspect import getargspec
 from django.apps import apps
 from django.test import TestCase
 from django.template import Template, Context
-from django.utils.six import text_type
 from django.utils.timesince import timesince
 from django.contrib.sites.models import Site
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
+from django.urls import reverse
 
 from actstream.models import Action, Follow
 from actstream.registry import register, unregister
@@ -53,7 +48,7 @@ class ActivityBaseTestCase(TestCase):
 
     def assertSetEqual(self, l1, l2, msg=None, domap=True):
         if domap:
-            l1 = map(text_type, l1)
+            l1 = map(str, l1)
         self.assertSequenceEqual(set(l1), set(l2), msg)
 
     def assertAllIn(self, bits, string):

--- a/actstream/tests/test_activity.py
+++ b/actstream/tests/test_activity.py
@@ -4,12 +4,7 @@ from django.contrib.auth.models import Group
 
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import activate, get_language
-from django.utils.six import text_type
-
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from actstream.models import (Action, Follow, model_stream, user_stream,
                               actor_stream, following, followers)
@@ -114,7 +109,7 @@ class ActivityTestCase(DataTestCase):
         self.assertEqual(created.actor, self.user1)
         self.assertEqual(created.action_object, self.comment)
         self.assertEqual(created.target, self.group)
-        self.assertEqual(text_type(created),
+        self.assertEqual(str(created),
                          'admin created comment admin: Sweet Group!... on '
                          'CoolGroup %s ago' % self.timesince)
 
@@ -271,14 +266,13 @@ class ActivityTestCase(DataTestCase):
         self.assertIn(self.join_action,
                       list(user_stream(self.user1, with_user_activity=True)))
 
-    if django.VERSION[:2] > (1, 4):
-        def test_store_untranslated_string(self):
-            lang = get_language()
-            activate('fr')
-            verb = _('English')
+    def test_store_untranslated_string(self):
+        lang = get_language()
+        activate('fr')
+        verb = _('English')
 
-            self.assertEqual(verb, 'Anglais')
-            action.send(self.user1, verb=verb, action_object=self.comment,
-                        target=self.group, timestamp=self.testdate)
-            self.assertTrue(Action.objects.filter(verb='English').exists())
-            activate(lang)
+        self.assertEqual(verb, 'Anglais')
+        action.send(self.user1, verb=verb, action_object=self.comment,
+                    target=self.group, timestamp=self.testdate)
+        self.assertTrue(Action.objects.filter(verb='English').exists())
+        activate(lang)

--- a/actstream/tests/test_views.py
+++ b/actstream/tests/test_views.py
@@ -12,13 +12,13 @@ class ViewsTest(DataTestCase):
         self.client.login(username='admin', password='admin')
 
     def get(self, viewname, *args, **params):
-        return self.client.get('%s?%s' % (reverse(viewname, args=args),
+        return self.client.get('{}?{}'.format(reverse(viewname, args=args),
                                           urlencode(params)))
 
     def assertQSEqual(self, qs1, qs2):
-        attrs = lambda item: dict([(key, value)
+        attrs = lambda item: {key: value
                                    for key, value in item.__dict__.items()
-                                   if not key.startswith('_')])
+                                   if not key.startswith('_')}
         self.assertEqual(len(qs1), len(qs2))
         for i, item in enumerate(qs1):
             self.assertDictEqual(attrs(item), attrs(qs2[i]))

--- a/actstream/tests/test_views.py
+++ b/actstream/tests/test_views.py
@@ -1,9 +1,6 @@
-from django.utils.six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
-try:
-    from django.core.urlresolvers import reverse
-except ImportError:
-    from django.urls import reverse
+from django.urls import reverse
 
 from actstream import models
 from actstream.tests.base import DataTestCase

--- a/actstream/tests/test_zombies.py
+++ b/actstream/tests/test_zombies.py
@@ -3,7 +3,6 @@ from random import choice
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import connection
-from django.utils.six import text_type
 
 from actstream.signals import action
 from actstream.models import model_stream
@@ -46,7 +45,7 @@ class ZombieTest(ActivityBaseTestCase):
     def check_query_count(self, queryset):
         ci = len(connection.queries)
 
-        result = list([map(text_type, (x.actor, x.target, x.action_object))
+        result = list([map(str, (x.actor, x.target, x.action_object))
                        for x in queryset])
         self.assertTrue(len(connection.queries) - ci <= 4,
                         'Too many queries, got %d expected no more than 4' %

--- a/actstream/urls.py
+++ b/actstream/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.urls import url
-except ImportError:
-    from django.conf.urls import url
+from django.conf.urls import url
 
 from actstream import feeds, views
 

--- a/actstream/views.py
+++ b/actstream/views.py
@@ -25,7 +25,7 @@ def respond(request, code):
 
 @login_required
 @csrf_exempt
-def follow_unfollow(request, content_type_id, object_id, flag, do_follow=True, actor_only=True):
+def follow_unfollow(request, content_type_id, object_id, flag=None, do_follow=True, actor_only=True):
     """
     Creates or deletes the follow relationship between ``request.user`` and the
     actor defined by ``content_type_id``, ``object_id``.
@@ -62,7 +62,7 @@ def stream(request):
     )
 
 
-def followers(request, content_type_id, object_id, flag):
+def followers(request, content_type_id, object_id, flag=None):
     """
     Creates a listing of ``User``s that follow the actor defined by
     ``content_type_id``, ``object_id``.
@@ -81,7 +81,7 @@ def followers(request, content_type_id, object_id, flag):
     )
 
 
-def following(request, user_id, flag):
+def following(request, user_id, flag=None):
     """
     Returns a list of actors that the user identified by ``user_id``
     is following (eg who im following).

--- a/runtests/testapp/urls.py
+++ b/runtests/testapp/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.urls import url
-except ImportError:
-    from django.conf.urls import url
+from django.conf.urls import url
 
 from actstream import feeds
 

--- a/runtests/urls.py
+++ b/runtests/urls.py
@@ -1,10 +1,7 @@
 import os
 from django.contrib import admin
 from django.views.static import serve
-try:
-    from django.urls import include, url
-except ImportError:
-    from django.conf.urls import include, url
+from django.conf.urls import include, url
 
 
 urlpatterns = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,15 @@
 [tox]
 envlist =
-    py{35,36}-django111-{mysql,postgres,sqlite}
-    py{35,36}-django21-{mysql,postgres}
-    py{35,36}-django22-{mysql,postgres}
+    py{36,37}-django22-{mysql,postgres}
+    py{36,37}-django30-{mysql,postgres}
 
 [testenv]
 commands = coverage run runtests/manage.py test -v3 --noinput actstream testapp testapp_nested
 
 deps =
     coverage>=4.5.1
-    django111: Django>=1.11,<2.0
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<4.0
     mysql: mysqlclient>=1.4.2,<1.5
     mysql: django-mysql>=2.4.1
     postgres,sqlite: django-jsonfield>=1.0.1
@@ -27,9 +25,8 @@ passenv = TRAVIS
 
 [travis:env]
 DJANGO =
-    1.11: django111
-    2.1: django21
     2.2: django22
+    3.0: django30
 DATABASE =
     mysql: mysql
     postgresql: postgresql


### PR DESCRIPTION
Progress on #438. This should handle all `ImportError` exceptions for APIs deprecated in Django 3, excluding the ones from dependencies used for JSON field support