### PR TITLE
Update link to django-jsonfield

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,7 +50,7 @@ The activity urls are not required for basic usage but provide activity :ref:`fe
 Add extra data to actions
 -------------------------
 
-If you want to use custom data on your actions, then make sure you have `django-jsonfield <https://bitbucket.org/schinckel/django-jsonfield/>`_ installed
+If you want to use custom data on your actions, then make sure you have `django-jsonfield <https://pypi.org/project/django-jsonfield/>`_ installed
 
 .. code-block:: bash
 


### PR DESCRIPTION
The currentl link points to bitbucket where the README reads: 
> django-jsonfield
> This project is now maintained by Adam Johnson and and hosted on GitHub at https://github.com/adamchainz/django-jsonfield .

So is confirmed by the PyPI listing where the homepage link points to Adam's repository.

The proposed change links to PyPI directly which is supposed to be the source of truth for those things :)