### PR TITLE
Add support of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from actstream import __version__
 
 setup(name='django-activity-stream',


### PR DESCRIPTION
Can we consider using setuptools with an optional fallback to distutils?

I think it's possible with the current setup.py file to support both options.

It will help a lot since I have troubles installing the package directly from the master using poetry:
https://github.com/python-poetry/poetry and this patch will resolve my issue.

Thanks for the great package!