### PR TITLE
Make sure Action.data field is not added twice in ActstreamConfig

### DIFF
--- a/actstream/apps.py
+++ b/actstream/apps.py
@@ -12,7 +12,7 @@ class ActstreamConfig(AppConfig):
         action.connect(action_handler, dispatch_uid='actstream.models')
         action_class = self.get_model('action')
 
-        if settings.USE_JSONFIELD:
+        if settings.USE_JSONFIELD and not hasattr(action_class, 'data'):
             from actstream.jsonfield import DataField, register_app
             DataField(blank=True, null=True).contribute_to_class(
                 action_class, 'data'

--- a/actstream/tests/test_apps.py
+++ b/actstream/tests/test_apps.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from django.apps.registry import apps
+
+
+class ActstreamConfigTestCase(TestCase):
+
+    def test_data_field_is_added_to_action_class_only_once_even_if_app_is_loaded_again(self):
+        actstream_config = apps.get_app_config('actstream')
+        actstream_config.ready()
+        actstream_config.ready()
+
+        from actstream.models import Action
+        data_fields = [field for field in Action._meta.fields if field.name == 'data']
+        self.assertEqual(
+            len(data_fields),
+            1
+        )


### PR DESCRIPTION
An app can be reloaded during tests if `INSTALLED_APPS` is modified using `override_settings` or `modify_settings`, this would cause the data field to be added to `Action._meta.fields` multiple times and this leads to an error when you try to save an action because django will generate an sql query with the data column included multiple times, this PR prevents that.