### PR TITLE
Feature of having with_user_activity=True parameter when using User Activity Feed  (User Stream) url

### DIFF
--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -24,7 +24,13 @@ class AbstractActivityStream(object):
         """
         Returns a stream method to use.
         """
-        raise NotImplementedError
+        raise NotImplementedError   
+    
+    def get_stream_kwargs(self, *args, **kwargs):
+        """
+        Returns the kwargs that the stream should be called with.
+        """
+        return {}
 
     def get_object(self, *args, **kwargs):
         """
@@ -213,7 +219,7 @@ class JSONActivityFeed(AbstractActivityStream, View):
                             content_type='application/json')
 
     def serialize(self, request, *args, **kwargs):
-        items = self.items(request, *args, **kwargs)
+        items = self.get_stream()(self.get_object(request, *args, **kwargs), **self.get_stream_kwargs(request))
         return json.dumps({
             'totalItems': len(items),
             'items': [self.format(action) for action in items]
@@ -252,13 +258,12 @@ class UserActivityMixin(object):
     def get_stream(self):
         return user_stream
 
-    def items(self, request, *args, **kwargs):
+    def get_stream_kwargs(self, request):
         stream_kwargs = {}
         if 'with_user_activity' in request.GET:
             stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
-        return self.get_stream()(self.get_object(request, *args, **kwargs),**stream_kwargs)
-
-
+        return stream_kwargs
+    
 class CustomStreamMixin(object):
     name = None
 

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -258,12 +258,16 @@ class UserActivityMixin(object):
     def get_stream(self):
         return user_stream
 
+<<<<<<< HEAD
     def get_stream_kwargs(self, request):
         stream_kwargs = {}
         if 'with_user_activity' in request.GET:
             stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
         return stream_kwargs
     
+=======
+
+>>>>>>> parent of 17e11e8... added  as query string in UserActivityFeed
 class CustomStreamMixin(object):
     name = None
 

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -24,7 +24,7 @@ class AbstractActivityStream(object):
         """
         Returns a stream method to use.
         """
-        raise NotImplementedError
+        raise NotImplementedError   
 
     def get_object(self, *args, **kwargs):
         """
@@ -242,6 +242,11 @@ class ObjectActivityMixin(object):
     def get_stream(self):
         return any_stream
 
+class StreamKwargsMixin(object):
+        
+    def items(self, request, *args, **kwargs):
+        return self.get_stream()(self.get_object(request, *args, **kwargs),**self.get_stream_kwargs(request))
+    
 
 class UserActivityMixin(object):
 
@@ -252,26 +257,12 @@ class UserActivityMixin(object):
     def get_stream(self):
         return user_stream
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     def get_stream_kwargs(self, request):
         stream_kwargs = {}
         if 'with_user_activity' in request.GET:
             stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
         return stream_kwargs
-    
-=======
 
->>>>>>> parent of 17e11e8... added  as query string in UserActivityFeed
-=======
-    def items(self, request, *args, **kwargs):
-        stream_kwargs = {}
-        if 'with_user_activity' in request.GET:
-            stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
-        return self.get_stream()(self.get_object(request, *args, **kwargs),**stream_kwargs)
-
-
->>>>>>> parent of 7577054... Feature of having with_user_activity=True parameter when using User Activity Feed
 class CustomStreamMixin(object):
     name = None
 
@@ -350,7 +341,7 @@ class AtomObjectActivityFeed(ObjectActivityFeed):
     subtitle = ObjectActivityFeed.description
 
 
-class UserJSONActivityFeed(UserActivityMixin, JSONActivityFeed):
+class UserJSONActivityFeed(UserActivityMixin, StreamKwargsMixin, JSONActivityFeed):
     """
     JSON feed of Activity for a given user (where actions are those that the given user follows).
     """

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -24,13 +24,7 @@ class AbstractActivityStream(object):
         """
         Returns a stream method to use.
         """
-        raise NotImplementedError   
-    
-    def get_stream_kwargs(self, *args, **kwargs):
-        """
-        Returns the kwargs that the stream should be called with.
-        """
-        return {}
+        raise NotImplementedError
 
     def get_object(self, *args, **kwargs):
         """
@@ -219,7 +213,7 @@ class JSONActivityFeed(AbstractActivityStream, View):
                             content_type='application/json')
 
     def serialize(self, request, *args, **kwargs):
-        items = self.get_stream()(self.get_object(request, *args, **kwargs), **self.get_stream_kwargs(request))
+        items = self.items(request, *args, **kwargs)
         return json.dumps({
             'totalItems': len(items),
             'items': [self.format(action) for action in items]
@@ -259,6 +253,7 @@ class UserActivityMixin(object):
         return user_stream
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     def get_stream_kwargs(self, request):
         stream_kwargs = {}
         if 'with_user_activity' in request.GET:
@@ -268,6 +263,15 @@ class UserActivityMixin(object):
 =======
 
 >>>>>>> parent of 17e11e8... added  as query string in UserActivityFeed
+=======
+    def items(self, request, *args, **kwargs):
+        stream_kwargs = {}
+        if 'with_user_activity' in request.GET:
+            stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
+        return self.get_stream()(self.get_object(request, *args, **kwargs),**stream_kwargs)
+
+
+>>>>>>> parent of 7577054... Feature of having with_user_activity=True parameter when using User Activity Feed
 class CustomStreamMixin(object):
     name = None
 

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from actstream.models import Action, model_stream, user_stream, any_stream
 
 
-class AbstractActivityStream(object):
+class AbstractActivityStream:
     """
     Abstract base class for all stream rendering.
     Supports hooks for fetching streams and formatting actions.
@@ -220,7 +220,7 @@ class JSONActivityFeed(AbstractActivityStream, View):
         }, indent=4 if 'pretty' in request.GET or 'pretty' in request.POST else None)
 
 
-class ModelActivityMixin(object):
+class ModelActivityMixin:
 
     def get_object(self, request, content_type_id):
         return get_object_or_404(ContentType, pk=content_type_id).model_class()
@@ -229,7 +229,7 @@ class ModelActivityMixin(object):
         return model_stream
 
 
-class ObjectActivityMixin(object):
+class ObjectActivityMixin:
 
     def get_object(self, request, content_type_id, object_id):
         ct = get_object_or_404(ContentType, pk=content_type_id)
@@ -242,13 +242,13 @@ class ObjectActivityMixin(object):
     def get_stream(self):
         return any_stream
 
-class StreamKwargsMixin(object):
+class StreamKwargsMixin:
         
     def items(self, request, *args, **kwargs):
         return self.get_stream()(self.get_object(request, *args, **kwargs),**self.get_stream_kwargs(request))
     
 
-class UserActivityMixin(object):
+class UserActivityMixin:
 
     def get_object(self, request):
         if request.user.is_authenticated:
@@ -263,7 +263,7 @@ class UserActivityMixin(object):
             stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
         return stream_kwargs
 
-class CustomStreamMixin(object):
+class CustomStreamMixin:
     name = None
 
     def get_object(self):

--- a/actstream/feeds.py
+++ b/actstream/feeds.py
@@ -252,6 +252,12 @@ class UserActivityMixin(object):
     def get_stream(self):
         return user_stream
 
+    def items(self, request, *args, **kwargs):
+        stream_kwargs = {}
+        if 'with_user_activity' in request.GET:
+            stream_kwargs['with_user_activity'] = request.GET['with_user_activity'].lower() == 'true'
+        return self.get_stream()(self.get_object(request, *args, **kwargs),**stream_kwargs)
+
 
 class CustomStreamMixin(object):
     name = None

--- a/actstream/tests/base.py
+++ b/actstream/tests/base.py
@@ -51,9 +51,9 @@ class ActivityBaseTestCase(TestCase):
             l1 = map(str, l1)
         self.assertSequenceEqual(set(l1), set(l2), msg)
 
-    def assertAllIn(self, bits, string):
+    def assertAllIn(self, bits, obj):
         for bit in bits:
-            self.assertIn(bit, string)
+            self.assertIn(bit, str(obj))
 
     def assertJSON(self, string):
         return loads(string)
@@ -67,8 +67,8 @@ class ActivityBaseTestCase(TestCase):
         Follow.objects.all().delete()
         self.User.objects.all().delete()
 
-    def capture(self, viewname, *args):
-        response = self.client.get(reverse(viewname, args=args))
+    def capture(self, viewname, *args, query_string=''):
+        response = self.client.get('{}?{}'.format(reverse(viewname, args=args),query_string))
         content = response.content.decode()
         if response['Content-Type'] == 'application/json':
             return loads(content)

--- a/actstream/tests/test_feeds.py
+++ b/actstream/tests/test_feeds.py
@@ -29,11 +29,19 @@ class FeedsTestCase(base.DataTestCase):
             'Two started following CoolGroup %s ago' % self.timesince,
             'Two joined CoolGroup %s ago' % self.timesince,
         ]
+        expected_json = expected[2:]
+        expected_json_with_user_activity = expected_json + ['admin started following Two %s ago' % self.timesince,
+        'admin joined CoolGroup %s ago' % self.timesince,
+        'admin commented on CoolGroup %s ago' % self.timesince
+        ]
         rss = self.capture('actstream_feed')
         self.assertAllIn(self.rss_base + expected, rss)
         atom = self.capture('actstream_feed_atom')
         self.assertAllIn(self.atom_base + expected, atom)
         json = self.capture('actstream_feed_json')
+        self.assertAllIn(expected_json, json)
+        json_with_user_activity = self.capture('actstream_feed_json', query_string='with_user_activity=true') 
+        self.assertAllIn(expected_json_with_user_activity, json_with_user_activity) 
 
     def test_model_feed(self):
         expected = [

--- a/docs/source/feeds.rst
+++ b/docs/source/feeds.rst
@@ -26,6 +26,14 @@ Shows user stream for currently logged in user.
     /activity/feed/atom/
     /activity/feed/json/
 
+If you want to include the user own activity, the optional parameter ``with_user_activity`` can be passed to the user stream as a query string parameter:
+
+.. code-block:: bash
+
+    /activity/feed/atom/?with_user_activity=true
+    /activity/feed/json/?with_user_activity=true
+ 
+
 :ref:`any-stream`
 
 .. code-block:: bash


### PR DESCRIPTION
I liked to have a feature that I can get the user own activity by passing ``with_user_activity=True`` through query parameter like ``/activity/feed/json/with_user_activity=true``. 

So I added the ``items`` function to ``UserActivityMixin``. Take a look at the code and tell me your comments about that or this feature.