### PR TITLE
Add docker env for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:focal
+
+ENV PYTHONUNBUFFERED 1
+ENV LC_ALL=C.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
+
+# the base image is also built using this Dockerfile, so we have to reset this
+USER root
+
+RUN apt-get -y update && apt-get -y --no-install-recommends install \
+    build-essential \
+    gcc \
+    gettext \
+    python3-dev \
+    python3-venv \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc/* /usr/share/locale/* /usr/share/man/* && \
+    mkdir -p /app && \
+    (useradd -m app || true)
+
+COPY --from=library/docker:latest /usr/local/bin/docker /usr/bin/docker
+COPY --from=docker/compose:1.23.2 /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+WORKDIR /app
+
+ADD runtests/requirements.txt /app/
+
+USER app
+
+ENV PATH /home/app/venv/bin:${PATH}
+
+RUN python3 -m venv ~/venv && \
+    pip install -r /app/requirements.txt
+
+ENV DJANGO_SETTINGS_MODULE settings
+
+# *WARNING*: DO NOT "ADD . /app" because it would include the current settings in the base image, which is uploaded by
+# CI to docker hub; Since the settings currently include secrets, this would leak our credentials!
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/manage.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.5"
+
+services:
+    django:
+        build: .
+        user: app
+        command: "runserver 0:8000"
+        volumes:
+            - ./runtests:/app:cached
+            - ./actstream:/app/actstream:cached
+            - /var/run/docker.sock:/var/run/docker.sock
+        environment:
+            IPYTHONDIR: /app/.ipython
+            HISTFILE: /app/.bash_history
+            PYTHONDONTWRITEBYTECODE: "x"
+            PYTHONWARNINGS: default
+        restart: unless-stopped

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,10 @@
+Developing on django-activity-stream
+====================================
+
+To simplify the development workflow, the project provides a docker container that can run the tests.
+
+You will need `docker <https://www.docker.com/>`_ and `Docker Compose <https://docs.docker.com/compose/>`_.
+
+.. code-block:: bash
+
+    docker-compose run --rm django test

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Contents:
    streams
    templatetags
    feeds
+   development
    changelog
    api
 

--- a/runtests/requirements.txt
+++ b/runtests/requirements.txt
@@ -1,0 +1,4 @@
+Django>=2.2.17
+django-jsonfield
+django-jsonfield-compat
+tblib


### PR DESCRIPTION
To simplify local development and reduce the need to have virtualenv and other libs installed, this PR adds a simple docker container to run tests in.