### PR TITLE
Fix documentation generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,9 @@ import os
 import sys
 from datetime import datetime
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'actstream.runtests.settings'
+os.environ['DJANGO_SETTINGS_MODULE'] = 'runtests.settings'
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../actstream/runtests'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../runtests'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
 import django


### PR DESCRIPTION
When running `make html` the documentation fails to build with:

```
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.5.3

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/sphinx/config.py", line 327, in eval_config_file
    execfile_(filename, namespace)
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/sphinx/util/pycompat.py", line 88, in execfile_
    exec(code, _globals)
  File "/home/james/code/github.com/django-activity-stream/docs/source/conf.py", line 24, in <module>
    django.setup()
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/home/james/code/github.com/django-activity-stream/.venv/lib/python3.8/site-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'actstream.runtests'
```

This is caused by the move of `actstream/runtests` to `runtests` in 21aee93959ee24bee995c4d47ceb4ca8eba0c2fb. This PR fixes this issue, so that `make html` works again.