### PR TITLE
Conditionally include 'default_app_config' to remove Django 4.x deprecation warning

### DIFF
--- a/actstream/__init__.py
+++ b/actstream/__init__.py
@@ -3,6 +3,10 @@ try:
 except:
     pass
 
+import django
+
 __version__ = '0.10.0'
 __author__ = 'Asif Saif Uddin, Justin Quick <justquick@gmail.com>'
-default_app_config = 'actstream.apps.ActstreamConfig'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'actstream.apps.ActstreamConfig'


### PR DESCRIPTION
Django 3.2 began deprecating usage of the `default_app_config` value in app folders in favor of automatic AppConfig discovery.  The value will be completely removed in Django 4.1.

https://code.djangoproject.com/ticket/31180

This commit conditionally checks the current Django version to omit setting the `default_app_config` value in Django 3.2 and newer.  This removes the RemovedInDjango41Warning emitted during application startup.

```
RemovedInDjango41Warning: 'actstream' defines default_app_config = 'actstream.apps.ActstreamConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```

Along with changes from #497 this should eliminate all known deprecation warnings for Django 4+ in active Django releases.