### PR TITLE
Fix django app config default warning

### DIFF
--- a/actstream/__init__.py
+++ b/actstream/__init__.py
@@ -8,5 +8,8 @@ import django
 __version__ = '1.4.0'
 __author__ = 'Asif Saif Uddin, Justin Quick <justquick@gmail.com>'
 
-if django.VERSION < (3, 2):
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
     default_app_config = 'actstream.apps.ActstreamConfig'


### PR DESCRIPTION
**What does this PR do ?**

It solves the fix warnings default_app_config.
Full error details :

`RemovedInDjango41Warning: 'actstream' defines default_app_config = 'actstream.apps.ActstreamConfig'. Django now detects this configuration automatically. You can remove default_app_config.`