### PR TITLE
docs: Fix a few typos

### DIFF
--- a/actstream/actions.py
+++ b/actstream/actions.py
@@ -109,7 +109,7 @@ def action_handler(verb, **kwargs):
     kwargs.pop('signal', None)
     actor = kwargs.pop('sender')
 
-    # We must store the unstranslated string
+    # We must store the untranslated string
     # If verb is an ugettext_lazyed string, fetch the original string
     if hasattr(verb, '_proxy____args'):
         verb = verb._proxy____args[0]

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -3,7 +3,7 @@
 Activity Stream Concepts
 ========================
 
-The terminiology used in this app is based from the `Activity Streams Specification <http://activitystrea.ms/>`_.
+The terminology used in this app is based from the `Activity Streams Specification <http://activitystrea.ms/>`_.
 The app currently supports the `version 1.0 <http://activitystrea.ms/specs/atom/1.0/>`_ terminology.
 
 Introduction


### PR DESCRIPTION
There are small typos in:
- actstream/actions.py
- docs/concepts.rst

Fixes:
- Should read `untranslated` rather than `unstranslated`.
- Should read `terminology` rather than `terminiology`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md